### PR TITLE
added env var for model cache, and pre-downloading in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,9 @@ COPY . /src/
 
 RUN pip install /src
 
+#pre-download the models here:
+ENV HIPPUNFOLD_CACHE_DIR=/opt/hippunfold_cache
+RUN hippunfold_download_models
+
 ENTRYPOINT [ "hippunfold" ]
 

--- a/hippunfold/download_models.py
+++ b/hippunfold/download_models.py
@@ -8,9 +8,16 @@ import errno
 
 
 def main():
-    #create local download dir if it doesn't exist
-    dirs = AppDirs('hippunfold','khanlab')
-    download_dir = dirs.user_cache_dir
+    
+    if 'HIPPUNFOLD_CACHE_DIR' in os.environ.keys():
+        print(f"HIPPUNFOLD_CACHE_DIR defined, using: {os.environ['HIPPUNFOLD_CACHE_DIR']}")
+        download_dir = os.environ['HIPPUNFOLD_CACHE_DIR']
+    else:
+        print(f'HIPPUNFOLD_CACHE_DIR not defined, using default location')
+        #create local download dir if it doesn't exist
+        dirs = AppDirs('hippunfold','khanlab')
+        download_dir = dirs.user_cache_dir
+
     try:
         os.mkdir(download_dir)
     except OSError as exc:


### PR DESCRIPTION
HIPPUNFOLD_CACHE_DIR can be used to specify model download directory, and this is used now in the Dockerfile to pre-download models into the container for portability.