### PR TITLE
Visualization QC reports

### DIFF
--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -11,12 +11,15 @@ derivatives: False #will search in bids/derivatives if True; can also be path(s)
 #list of analysis levels in the bids app 
 analysis_levels: &analysis_levels
  - participant
+ - group
   
 
 #mapping from analysis_level to set of target rules or files
 targets_by_analysis_level:
   participant:
-    - ''  # if '', then the first rule is run
+    - 'all'  # if '', then the first rule is run
+  group:
+    - 'all_group_tsv'
 
 #this configures the pybids grabber - create an entry for each type of input you want to grab
 # indexed by name of input

--- a/hippunfold/workflow/Snakefile
+++ b/hippunfold/workflow/Snakefile
@@ -100,8 +100,23 @@ def get_final_anat():
  
 def get_final_qc():
     qc = []
-    qc = qc + expand(bids(root='work',**config['subj_wildcards'],suffix='regqc.png',
+    qc = qc + expand(bids(root='work',datatype='qc',**config['subj_wildcards'],suffix='regqc.png',
                 from_='subject', to=config['template']),**config['input_lists']['T1w'])
+
+    for modality in config['modality']:
+        mod_index = get_modality_key(modality)
+        qc = qc + \
+            expand(bids(root='work',datatype='qc',suffix='dseg.png', desc='subfields',from_='{modality}',space='cropT1w',hemi='{hemi}', **config['subj_wildcards']),
+                modality=modality,
+                hemi=['L','R'],
+                subject=config['input_lists'][mod_index]['subject'],
+                session=config['sessions'])
+        qc = qc + \
+            expand(bids(root='work',datatype='qc',desc='subfields',from_='{modality}',suffix='volumes.png',**config['subj_wildcards']),
+                modality=modality,
+                subject=config['input_lists'][mod_index]['subject'],
+                session=config['sessions'])
+
     return qc
 
 rule all:

--- a/hippunfold/workflow/Snakefile
+++ b/hippunfold/workflow/Snakefile
@@ -96,13 +96,21 @@ def get_final_anat():
                 session=config['sessions'])
 
     return anat
+
  
+def get_final_qc():
+    qc = []
+    qc = qc + expand(bids(root='work',**config['subj_wildcards'],suffix='regqc.png',
+                from_='subject', to=config['template']),**config['input_lists']['T1w'])
+    return qc
+
 rule all:
     input: 
         get_final_specs(),
         get_final_subfields(),
         get_final_coords(),
-        get_final_anat()
+        get_final_anat(),
+        get_final_qc(),
 
 include: 'rules/common.smk'
 include: 'rules/preproc_t1.smk'

--- a/hippunfold/workflow/Snakefile
+++ b/hippunfold/workflow/Snakefile
@@ -127,6 +127,11 @@ rule all:
         get_final_anat(),
         get_final_qc(),
 
+rule all_group_tsv:
+    input: 
+        tsv = expand(bids(root='results',prefix='group',from_='{modality}',desc='subfields',suffix='volumes.tsv'),
+                    modality=config['modality'])
+
 include: 'rules/common.smk'
 include: 'rules/preproc_t1.smk'
 

--- a/hippunfold/workflow/report/subfield_qc.rst
+++ b/hippunfold/workflow/report/subfield_qc.rst
@@ -1,0 +1,1 @@
+Subfields segmentation

--- a/hippunfold/workflow/report/subj_volume_plot.rst
+++ b/hippunfold/workflow/report/subj_volume_plot.rst
@@ -1,0 +1,1 @@
+Subfield volumes

--- a/hippunfold/workflow/report/t1w_template_regqc.rst
+++ b/hippunfold/workflow/report/t1w_template_regqc.rst
@@ -1,0 +1,1 @@
+T1w to template registration

--- a/hippunfold/workflow/rules/preproc_t1.smk
+++ b/hippunfold/workflow/rules/preproc_t1.smk
@@ -46,6 +46,19 @@ rule reg_to_template:
     shell:
         'reg_aladin -flo {input.flo} -ref {input.ref} -res {output.warped_subj} -aff {output.xfm_ras} {params.rigid}'
 
+rule qc_reg_to_template:
+    input:
+        ref = os.path.join(config['snakemake_dir'],config['template_files'][config['template']]['T1w']),
+        flo = bids(root='work',datatype='anat',**config['subj_wildcards'],suffix='T1w.nii.gz',space=config['template'],desc='affine'),
+    output:
+        png = report(bids(root='work',**config['subj_wildcards'],suffix='regqc.png',from_='subject', to=config['template']),
+                caption='../report/t1w_template_regqc.rst',
+                category='Registration QC',
+                subcategory=f"T1w to {config['template']}"),
+        html = bids(root='work',**config['subj_wildcards'],suffix='regqc.html',from_='subject', to=config['template'])
+    group: 'subj'
+    script: '../scripts/vis_regqc.py'
+
 
 
 rule convert_template_xfm_ras2itk:

--- a/hippunfold/workflow/rules/preproc_t1.smk
+++ b/hippunfold/workflow/rules/preproc_t1.smk
@@ -51,11 +51,9 @@ rule qc_reg_to_template:
         ref = os.path.join(config['snakemake_dir'],config['template_files'][config['template']]['T1w']),
         flo = bids(root='work',datatype='anat',**config['subj_wildcards'],suffix='T1w.nii.gz',space=config['template'],desc='affine'),
     output:
-        png = report(bids(root='work',**config['subj_wildcards'],suffix='regqc.png',from_='subject', to=config['template']),
+        png = report(bids(root='work',datatype='qc',**config['subj_wildcards'],suffix='regqc.png',from_='subject', to=config['template']),
                 caption='../report/t1w_template_regqc.rst',
-                category='Registration QC',
-                subcategory=f"T1w to {config['template']}"),
-        html = bids(root='work',**config['subj_wildcards'],suffix='regqc.html',from_='subject', to=config['template'])
+                category='Registration QC')
     group: 'subj'
     script: '../scripts/vis_regqc.py'
 

--- a/hippunfold/workflow/rules/resample_final_to_crop_t1.smk
+++ b/hippunfold/workflow/rules/resample_final_to_crop_t1.smk
@@ -11,7 +11,7 @@ rule create_native_crop_ref:
     container: config['singularity']['autotop']
     group: 'subj'
     shell:
-        'c3d {input} -binarize -interpolation NearestNeighbor -trim 0vox -resample {params.resample} -pad-to {params.pad_to} 0 {output}'
+        'c3d {input} -binarize -interpolation NearestNeighbor -trim 0vox -resample {params.resample} -pad-to {params.pad_to} 0 -type uchar {output}'
   
  
 
@@ -94,5 +94,6 @@ rule resample_t2_to_crop:
     shell:
         'ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS={threads} '
         'antsApplyTransforms -d 3 --interpolation Linear -i {input.nii} -o {output.nii} -r {input.ref} -t {input.xfm}' 
+
 
 

--- a/hippunfold/workflow/rules/subfields.smk
+++ b/hippunfold/workflow/rules/subfields.smk
@@ -36,7 +36,7 @@ rule combine_tissue_subfield_labels_corobl:
     container: config['singularity']['autotop']
     group: 'subj'
     shell: 
-        'c3d {input.tissue} -dup {params.remap_dg} -dup {params.remap_srlm} {params.remap_cyst} {input.subfields} -push dg -max -push srlm -max -push cyst -max -o {output}'
+        'c3d {input.tissue} -dup {params.remap_dg} -dup {params.remap_srlm} {params.remap_cyst} {input.subfields} -push dg -max -push srlm -max -push cyst -max -type uchar -o {output}'
 
 
 
@@ -83,6 +83,43 @@ rule resample_unet_to_T1w:
     shell:
         'ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS={threads} '
         'antsApplyTransforms -d 3 --interpolation MultiLabel -i {input.nii} -o {output.nii} -r {input.ref}  -t [{input.xfm},1]' 
+
+
+rule get_subfield_vols_subj:
+    """Export segmentation volume for a subject to TSV"""
+    input: 
+        segs = expand(bids(root='results',**config['subj_wildcards'],datatype='seg_{modality}',hemi='{hemi}',space='cropT1w',desc='subfields',suffix='dseg.nii.gz'),
+                    hemi=['L','R'], allow_missing=True),
+        lookup_tsv = os.path.join(config['snakemake_dir'],'resources','desc-subfields_dseg.tsv')
+    group: 'subj'
+    output: 
+        tsv = bids(root='results',datatype='seg_{modality}',desc='subfields',suffix='volumes.tsv',**config['subj_wildcards']),
+    script: '../scripts/gen_volume_tsv.py'
+
+
+
+rule plot_subj_subfields:
+    input:
+        tsv = bids(root='results',datatype='seg_{modality}',desc='subfields',suffix='volumes.tsv',**config['subj_wildcards'])
+    output:
+        png = report(bids(root='work',datatype='qc',desc='subfields',from_='{modality}',suffix='volumes.png',**config['subj_wildcards']),
+                caption='../report/subj_volume_plot.rst',
+                category='Subfield Volumes')
+    group: 'subj'
+    script: '../scripts/plot_subj_subfields.py'
+
+
+rule qc_subfield_t2:
+    input:
+        img = bids(root='results',datatype='seg_{modality}',desc='preproc',suffix='T2w.nii.gz', space='cropT1w',hemi='{hemi}', **config['subj_wildcards']),
+        seg = bids(root='results',datatype='seg_{modality}',suffix='dseg.nii.gz', desc='subfields',space='cropT1w',hemi='{hemi}', **config['subj_wildcards'])
+    output:
+        png = report(bids(root='work',datatype='qc',suffix='dseg.png', desc='subfields',from_='{modality}',space='cropT1w',hemi='{hemi}', **config['subj_wildcards']),
+                caption='../report/subfield_qc.rst',
+                category='Segmentation QC',
+                subcategory='Subfields from {modality}'),
+    group: 'subj'
+    script: '../scripts/vis_qc_dseg.py'
 
 
 

--- a/hippunfold/workflow/rules/subfields.smk
+++ b/hippunfold/workflow/rules/subfields.smk
@@ -122,4 +122,16 @@ rule qc_subfield_t2:
     script: '../scripts/vis_qc_dseg.py'
 
 
+rule concat_subj_vols_tsv:
+    """Concatenate all subject tsv files into a single tsv"""
+    input: 
+        tsv = lambda wildcards: expand(bids(root='results',datatype=f'seg_{wildcards.modality}',desc='subfields',suffix='volumes.tsv',**config['subj_wildcards']),
+                    subject=config['input_lists'][get_modality_key(wildcards.modality)]['subject'],
+                    session=config['sessions'])
+    group: 'aggregate'
+    output: 
+        tsv = bids(root='results',prefix='group',from_='{modality}',desc='subfields',suffix='volumes.tsv'),
+    run: 
+        import pandas as pd
+        pd.concat([pd.read_table(in_tsv) for in_tsv in input ]).to_csv(output.tsv,sep='\t',index=False)
 

--- a/hippunfold/workflow/scripts/gen_volume_tsv.py
+++ b/hippunfold/workflow/scripts/gen_volume_tsv.py
@@ -1,0 +1,34 @@
+import nibabel as nib
+import pandas as pd
+import numpy as np
+
+lookup_df = pd.read_table(snakemake.input.lookup_tsv,index_col='index')
+
+#get indices and names from lookup table
+indices = lookup_df.index.to_list()
+names = lookup_df.abbreviation.to_list()
+hemis = ['L','R']
+
+#create the output dataframe
+
+df = pd.DataFrame(columns = ['subject','hemi'] + names)
+
+
+for in_img,hemi in zip(snakemake.input.segs,hemis):
+
+    img_nib = nib.load(in_img)
+    img = img_nib.get_fdata()
+    zooms = img_nib.header.get_zooms()
+
+    #voxel size in mm^3
+    voxel_mm3 = np.prod(zooms)
+
+    new_entry = {'subject': 'sub-{subject}'.format(subject = snakemake.wildcards['subject']),'hemi': hemi}
+    for index,name in zip(indices,names):
+        # add volume as value, name as key
+        new_entry[name] = np.sum(img==index) * voxel_mm3
+
+    #now create a dataframe from it
+    df = df.append(new_entry, ignore_index=True)
+   
+df.to_csv(snakemake.output.tsv,sep='\t', index=False)

--- a/hippunfold/workflow/scripts/plot_subj_subfields.py
+++ b/hippunfold/workflow/scripts/plot_subj_subfields.py
@@ -1,0 +1,17 @@
+import matplotlib.pyplot as plt
+import matplotlib
+matplotlib.use('Agg')
+
+import pandas as pd
+import seaborn as sns
+
+df = pd.read_table(snakemake.input.tsv)
+
+subjdf = df.drop(columns=['subject','hemi','Cyst']).transpose()
+subjdf.columns=['L','R']
+
+sns_plot = sns.lineplot(data=subjdf)
+sns_plot.set_title(str(snakemake.wildcards))
+sns_plot.set_ylabel('Volume (mm^3)')
+sns_plot.get_figure().savefig(snakemake.output.png)
+

--- a/hippunfold/workflow/scripts/vis_qc_dseg.py
+++ b/hippunfold/workflow/scripts/vis_qc_dseg.py
@@ -1,0 +1,19 @@
+from nilearn import plotting
+import matplotlib.pyplot as plt
+
+
+import matplotlib
+matplotlib.use('Agg')
+
+html_view = plotting.view_img(stat_map_img=snakemake.input.seg,bg_img=snakemake.input.img,
+                              opacity=0.5,cmap='viridis',dim=-1,threshold=0.5,
+                              symmetric_cmap=False,title='sub-{subject}'.format(**snakemake.wildcards))
+
+html_view.save_as_html(snakemake.output.html)
+
+
+
+display = plotting.plot_roi(roi_img=snakemake.input.seg, bg_img=snakemake.input.img, display_mode='ortho')
+display.savefig(snakemake.output.png)
+display.close()
+

--- a/hippunfold/workflow/scripts/vis_qc_dseg.py
+++ b/hippunfold/workflow/scripts/vis_qc_dseg.py
@@ -1,19 +1,11 @@
 from nilearn import plotting
 import matplotlib.pyplot as plt
-
+import matplotlib.gridspec as gridspec
 
 import matplotlib
 matplotlib.use('Agg')
 
-html_view = plotting.view_img(stat_map_img=snakemake.input.seg,bg_img=snakemake.input.img,
-                              opacity=0.5,cmap='viridis',dim=-1,threshold=0.5,
-                              symmetric_cmap=False,title='sub-{subject}'.format(**snakemake.wildcards))
+fig = plotting.plot_roi(roi_img=snakemake.input.seg, bg_img=snakemake.input.img, display_mode='ortho',view_type='continuous',alpha=0.5,dim=-1,draw_cross=False)
 
-html_view.save_as_html(snakemake.output.html)
-
-
-
-display = plotting.plot_roi(roi_img=snakemake.input.seg, bg_img=snakemake.input.img, display_mode='ortho')
-display.savefig(snakemake.output.png)
-display.close()
+fig.savefig(snakemake.output.png)
 

--- a/hippunfold/workflow/scripts/vis_regqc.py
+++ b/hippunfold/workflow/scripts/vis_regqc.py
@@ -1,0 +1,20 @@
+from nilearn import plotting
+import matplotlib.pyplot as plt
+
+
+import matplotlib
+matplotlib.use('Agg')
+
+html_view = plotting.view_img(stat_map_img=snakemake.input.ref,bg_img=snakemake.input.flo,
+                              opacity=0.5,cmap='viridis',dim=-1,
+                              symmetric_cmap=False,title='sub-{subject}'.format(**snakemake.wildcards))
+
+html_view.save_as_html(snakemake.output.html)
+
+
+
+display = plotting.plot_anat(snakemake.input.flo,display_mode='ortho')
+display.add_contours(snakemake.input.ref,colors='r')
+display.savefig(snakemake.output.png)
+display.close()
+

--- a/hippunfold/workflow/scripts/vis_regqc.py
+++ b/hippunfold/workflow/scripts/vis_regqc.py
@@ -5,15 +5,7 @@ import matplotlib.pyplot as plt
 import matplotlib
 matplotlib.use('Agg')
 
-html_view = plotting.view_img(stat_map_img=snakemake.input.ref,bg_img=snakemake.input.flo,
-                              opacity=0.5,cmap='viridis',dim=-1,
-                              symmetric_cmap=False,title='sub-{subject}'.format(**snakemake.wildcards))
-
-html_view.save_as_html(snakemake.output.html)
-
-
-
-display = plotting.plot_anat(snakemake.input.flo,display_mode='ortho')
+display = plotting.plot_anat(snakemake.input.flo,display_mode='ortho',dim=-1)
 display.add_contours(snakemake.input.ref,colors='r')
 display.savefig(snakemake.output.png)
 display.close()

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ setuptools.setup(
         "pandas",
         "nibabel",
         "numpy",
-        "scipy"
+        "scipy",
+        "seaborn"
     ],
     python_requires='>=3.7'
 )


### PR DESCRIPTION
This PR adds visualization quick-checks for the HTML report, using some nilearn code adapted from the snakedwi workflow.

- `vis_regqc.py`: plots edge contours from flo image over the ref image. Currently used to QC the T1w to CIT template registration
- `vis_dseg.py`: plots orthoslice of bg img and overlaid semi-transparent segmentation. Currently used to QC the subfield seg in cropT1w space
- `gen_volume_tsv.py`: uses pandas and nibabel to create a df and write subject subfield volumes to tsv
- `plot_subj_subfields.py`: uses a tsv of subfield volumes to plot line plots (lh and rh) for a subject

The plotting scripts can be used generally for any other images in the workflow as needed.

I am placing all the QC png files in the work/ folder, and the TSV in the subject results folder.

To do:
- [x] add python code to merge the subject subfield TSVs (this had been created already, just need to integrate it into the workflow -- I plan on making this rule the `group` analysis level, since it aggregates over subjects)