### PR TITLE
some additions to CIFTI outputs

### DIFF
--- a/hippunfold/workflow/rules/gifti.smk
+++ b/hippunfold/workflow/rules/gifti.smk
@@ -196,7 +196,10 @@ rule create_spec_file:
                     shape=['gyrification','curvature','thickness'], allow_missing=True),
         surfs = expand(bids(root='results',datatype='surf_{modality}',suffix='{surfname}.surf.gii', space='{space}', hemi='{hemi}', **config['subj_wildcards']),
                     surfname=['midthickness','inner','outer'], space=['T1w','unfolded'], allow_missing=True), 
-        subfields = bids(root='results',datatype='surf_{modality}',suffix='subfields.label.gii', space='T1w',hemi='{hemi}', **config['subj_wildcards'])
+        subfields = bids(root='results',datatype='surf_{modality}',suffix='subfields.label.gii', space='T1w',hemi='{hemi}', **config['subj_wildcards']),
+        cifti = expand(bids(root='results',datatype='surf_{modality}',suffix='{cifti}.nii', space='T1w', **config['subj_wildcards']),
+                    cifti=['gyrification.dscalar','curvature.dscalar','thickness.dscalar','subfields.dlabel'], allow_missing=True),
+
     params:
         cmds = get_cmd_spec_file
     output: 
@@ -210,26 +213,11 @@ rule merge_lr_spec_file:
         spec_files = expand(bids(root='results',datatype='surf_{modality}',suffix='hippunfold.spec', hemi='{hemi}',**config['subj_wildcards']),
                         hemi=['L','R'], allow_missing=True)
     output: 
-        spec_file = bids(root='work',datatype='surf_{modality}',desc='merged',suffix='hippunfold.spec', **config['subj_wildcards'])
+        spec_file = bids(root='results',datatype='surf_{modality}',suffix='hippunfold.spec', **config['subj_wildcards'])
     container: config['singularity']['autotop']
     group: 'subj' 
     shell: 'wb_command -spec-file-merge {input.spec_files} {output}'
 
-
-
-rule add_cifti_to_spec_file:
-    """ Adds the cifti dscalar and dlabel files to the LR-merged cifti """ 
-    input:
-        cifti = expand(bids(root='results',datatype='surf_{modality}',suffix='{cifti}.nii', space='T1w', **config['subj_wildcards']),
-                    cifti=['gyrification.dscalar','curvature.dscalar','thickness.dscalar','subfields.dlabel'], allow_missing=True),
-        spec_file = bids(root='work',datatype='surf_{modality}',desc='merged',suffix='hippunfold.spec', **config['subj_wildcards'])
-    params:
-        cmds = get_cmd_spec_file
-    output: 
-        spec_file = bids(root='results',datatype='surf_{modality}',suffix='hippunfold.spec', **config['subj_wildcards'])
-    container: config['singularity']['autotop']
-    group: 'subj' 
-    shell: 'cp {input.spec_file} {output.spec_file} && {params.cmds}'
 
 
 

--- a/hippunfold/workflow/rules/gifti.smk
+++ b/hippunfold/workflow/rules/gifti.smk
@@ -196,6 +196,7 @@ rule create_spec_file:
                     shape=['gyrification','curvature','thickness'], allow_missing=True),
         surfs = expand(bids(root='results',datatype='surf_{modality}',suffix='{surfname}.surf.gii', space='{space}', hemi='{hemi}', **config['subj_wildcards']),
                     surfname=['midthickness','inner','outer'], space=['T1w','unfolded'], allow_missing=True), 
+        subfields = bids(root='results',datatype='surf_{modality}',suffix='subfields.label.gii', space='T1w',hemi='{hemi}', **config['subj_wildcards'])
     params:
         cmds = get_cmd_spec_file
     output: 

--- a/hippunfold/workflow/rules/gifti.smk
+++ b/hippunfold/workflow/rules/gifti.smk
@@ -134,6 +134,14 @@ rule calculate_thickness_from_surface:
         "wb_command -surface-to-surface-3d-distance {input.outer} {input.inner} {output}"    
 
 
+rule get_bigbrain_subfield_label_gii:
+    input:
+        gii = os.path.join(config['snakemake_dir'],'resources','bigbrain','sub-bigbrain_hemi-{hemi}_subfields.label.gii')
+    output:
+        gii = bids(root='results',datatype='surf_{modality}',suffix='subfields.label.gii', space='T1w',hemi='{hemi}', **config['subj_wildcards'])
+    group: 'subj'
+    shell: 'cp {input} {output}'
+
 rule create_dscalar_metric_cifti:
     input:
         left_metric = bids(root='results',datatype='surf_{modality}',suffix='{metric}.shape.gii', space='T1w',hemi='L', **config['subj_wildcards']),
@@ -146,10 +154,11 @@ rule create_dscalar_metric_cifti:
         'wb_command  -cifti-create-dense-scalar {output}'
         ' -left-metric {input.left_metric} -right-metric {input.right_metric}'
 
+
 rule create_dlabel_cifti_subfields:
     input:
-        left_label = os.path.join(config['snakemake_dir'],'resources','bigbrain','sub-bigbrain_hemi-L_subfields.label.gii'),
-        right_label = os.path.join(config['snakemake_dir'],'resources','bigbrain','sub-bigbrain_hemi-R_subfields.label.gii')
+        left_label = bids(root='results',datatype='surf_{modality}',suffix='subfields.label.gii', space='T1w',hemi='L', **config['subj_wildcards']),
+        right_label = bids(root='results',datatype='surf_{modality}',suffix='subfields.label.gii', space='T1w',hemi='R', **config['subj_wildcards'])
     output:
         cifti = bids(root='results',datatype='surf_{modality}',suffix='subfields.dlabel.nii', space='T1w', **config['subj_wildcards'])
     container: config['singularity']['autotop']

--- a/hippunfold/workflow/rules/gifti.smk
+++ b/hippunfold/workflow/rules/gifti.smk
@@ -56,12 +56,18 @@ rule warp_gii_unfold2native:
 rule unflip_gii:
     input:
         gii = bids(root='work',datatype='surf_{modality}',suffix='{surfname}.surf.gii', space='corobl',hemi='{hemi}flip', **config['subj_wildcards'])
+    params:
+        structure_type = lambda wildcards: hemi_to_structure[wildcards.hemi],
+        secondary_type = lambda wildcards: surf_to_secondary_type[wildcards.surfname],
+        surface_type = 'ANATOMICAL'
     output:
         gii = bids(root='work',datatype='surf_{modality}',suffix='{surfname}.surf.gii', space='corobl',hemi='{hemi,L}', **config['subj_wildcards'])
     container: config['singularity']['autotop']
     group: 'subj'
     shell:
-        'wb_command -surface-flip-lr {input.gii} {output.gii}'
+        'wb_command -surface-flip-lr {input.gii} {output.gii} && '
+        'wb_command -set-structure {output.gii} {params.structure_type} -surface-type {params.surface_type}'
+        ' -surface-secondary-type {params.secondary_type}'
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,8 @@ setuptools.setup(
         'hippunfold_download_models=hippunfold.download_models:main'
     ]},
     install_requires=[
-        "snakebids==0.2.1",
-        "snakemake>=5.28.0",
+        "snakebids>=0.3.7",
+        "snakemake>=6",
         "nnunet @ git+https://github.com/ylugithub/nnUNet.git@v1.6.6",
         "appdirs",
         "pandas",

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setuptools.setup(
         'hippunfold_download_models=hippunfold.download_models:main'
     ]},
     install_requires=[
-        "snakebids>=0.2.0",
+        "snakebids==0.2.1",
         "snakemake>=5.28.0",
         "nnunet @ git+https://github.com/ylugithub/nnUNet.git@v1.6.6",
         "appdirs",


### PR DESCRIPTION
This PR adds in generation of CIFTI data too (not just GIFTI). Also aims to add in the missing subfield label gifti data (referenced in #10 )

- [x] added dscalar (thickness, curvature, gyrfication) and subfield dlabel cifti to spec file
- [x] add the subfield label giftis too
- [x] make sure all the gifti/cifti structures are being set properly, I recall seeing CORTEX_LEFT  missing for some files
- [x] test the changes

