### PR TITLE
fast laplace via initialization

### DIFF
--- a/hippunfold/workflow/scripts/laplace_coords.py
+++ b/hippunfold/workflow/scripts/laplace_coords.py
@@ -51,8 +51,8 @@ backward = skfmm.travel_time(phi,np.ones_like(lbl))
 backward = backward.data
 # combine
 forward = forward/np.max(forward)
-backward = -backward/np.max(backward) +1
-init_coords = np.sqrt(np.square(forward) + np.square(backward))
+backward = backward/np.max(backward)
+init_coords = np.sqrt(np.square(forward) - np.square(backward) +1)
 init_coords = init_coords/np.max(init_coords)
 init_coords[idxgm==0] = 0
 

--- a/hippunfold/workflow/scripts/laplace_coords.py
+++ b/hippunfold/workflow/scripts/laplace_coords.py
@@ -52,7 +52,7 @@ backward = backward.data
 # combine
 forward = forward/np.max(forward)
 backward = backward/np.max(backward)
-init_coords = np.sqrt(np.square(forward) - np.square(backward) +1)
+init_coords = (forward + backward)/2
 init_coords = init_coords/np.max(init_coords)
 init_coords[idxgm==0] = 0
 

--- a/hippunfold/workflow/scripts/laplace_coords.py
+++ b/hippunfold/workflow/scripts/laplace_coords.py
@@ -50,15 +50,11 @@ phi = np.ma.MaskedArray(phi,mask)
 backward = skfmm.travel_time(phi,np.ones_like(lbl))
 backward = backward.data
 # combine
-print(f'check1', file=logfile, flush=True)
 forward = forward/np.max(forward)
 backward = -backward/np.max(backward) +1
-print(f'check2', file=logfile, flush=True)
 init_coords = np.sqrt(np.square(forward) + np.square(backward))
 init_coords = init_coords/np.max(init_coords)
-print(f'check3', file=logfile, flush=True)
 init_coords[idxgm==0] = 0
-print(f'check4', file=logfile, flush=True)
 
 # set up filter (18NN)
 hl=np.zeros([3,3,3])

--- a/hippunfold/workflow/scripts/laplace_coords.py
+++ b/hippunfold/workflow/scripts/laplace_coords.py
@@ -52,6 +52,7 @@ backward = backward.data
 # combine
 forward = forward/np.max(forward)
 backward = backward/np.max(backward)
+backward = -backward +1
 init_coords = (forward + backward)/2
 init_coords = init_coords/np.max(init_coords)
 init_coords[idxgm==0] = 0

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,8 @@ setuptools.setup(
         "seaborn",
         "jinja2",
         "pygraphviz",
-        "pygments"
+        "pygments",
+        "scikit-fmm"
     ],
     python_requires='>=3.7'
 )


### PR DESCRIPTION
I recycled some old matlab code to get a fast (and good quality) initialization for the lapalce solver. Only dependency is scikit-fmm which is pretty light.
This could be used in conjunction with image pyramids as in https://github.com/khanlab/hippunfold/issues/85, but honestly I think this is fast enough now. 

Tested and working on my end!