### PR TITLE
bugfix: container used in correct_nan_vertices

### DIFF
--- a/hippunfold/workflow/rules/gifti.smk
+++ b/hippunfold/workflow/rules/gifti.smk
@@ -58,7 +58,6 @@ rule correct_nan_vertices:
         gii = bids(root='work',datatype='surf_{modality}',den='{density}',suffix='{surfname}.surf.gii', desc='nonancorrect', space='corobl',hemi='{hemi}', **config['subj_wildcards'])
     output:
         gii = bids(root='work',datatype='surf_{modality}',den='{density}',suffix='{surfname}.surf.gii', space='corobl',hemi='{hemi,R|Lflip}', **config['subj_wildcards'])
-    container: config['singularity']['autotop']
     group: 'subj'
     script: '../scripts/fillnanvertices.py'
 


### PR DESCRIPTION
removed using this container in the rule since it is python
fyi: @jordandekraker 