### PR TITLE
No more overlapping points in griddata interpolation in create_warps.py

### DIFF
--- a/hippunfold/workflow/rules/autotop.smk
+++ b/hippunfold/workflow/rules/autotop.smk
@@ -105,6 +105,7 @@ rule map_to_full_grid:
         warpitk_native2unfold= bids(root='work',**config['subj_wildcards'],suffix='autotop/WarpITK_native2unfold.nii',desc='cropped',space='corobl',hemi='{hemi}',modality='{modality}'),
         unfold_ref = bids(root='work',space='unfold',suffix='refvol.nii.gz',**config['subj_wildcards'])
     params:
+        dims = config['unfold_vol_ref']['dims'],
         script = os.path.join(config['snakemake_dir'],'workflow','scripts','mapUnfoldToFullGrid.sh'),
         warp_dir = bids(root='work',**config['subj_wildcards'],suffix='autotop',desc='cropped',space='corobl',hemi='{hemi,Lflip|R}',modality='{modality}')
     output:
@@ -120,7 +121,7 @@ rule map_to_full_grid:
     log: bids(root='logs',**config['subj_wildcards'],space='corobl',hemi='{hemi,Lflip|R}',modality='seg{modality}',suffix='mapUnfoldToFullGrid.txt')
     shell:
         'SINGULARITYENV_ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS={threads} '
-        '{params.script} {input.coords_ap} {input.coords_pd} {input.coords_io} {input.unfold_ref} {params.warp_dir} &> {log}'
+        '{params.script} {input.coords_ap} {input.coords_pd} {input.coords_io} {input.unfold_ref} {params.warp_dir} {params.dims} &> {log}'
 
 
 rule compose_warps_corobl2unfold_rhemi:

--- a/hippunfold/workflow/rules/autotop.smk
+++ b/hippunfold/workflow/rules/autotop.smk
@@ -88,6 +88,7 @@ rule create_warps:
         warpitk_native2unfold= bids(root='work',**config['subj_wildcards'],suffix='autotop/WarpITK_native2unfold.nii',desc='cropped',space='corobl',hemi='{hemi,Lflip|R}',modality='{modality}'),
         #warp_unfold2native_extrap = bids(root='work',**config['subj_wildcards'],suffix='autotop/Warp_unfold2native_extrapolateNearest.nii',desc='cropped',space='corobl',hemi='{hemi,Lflip|R}',modality='{modality}'),
     group: 'subj'
+    log: bids(root='logs',**config['subj_wildcards'],hemi='{hemi,Lflip|R}',modality='seg-{modality}',suffix='create_warps.txt')
     script: '../scripts/create_warps.py'
 
 # TODO: add this extrapolation of the warp file, extrapolate_warp_unfold2native.m

--- a/hippunfold/workflow/scripts/create_warps.py
+++ b/hippunfold/workflow/scripts/create_warps.py
@@ -34,7 +34,7 @@ coord_pd = coord_pd_nib.get_fdata()
 coord_io = coord_io_nib.get_fdata()
 
 #get mask of coords  (note: this leaves out coord=0)
-mask = (coord_ap > 0) | (coord_pd > 0) | (coord_io > 0) # some points were lost, especially IO
+mask = (coord_ap > 0) | (coord_pd > 0) # some points were lost, especially IO
 num_mask_voxels = np.sum(mask>0)
 print(f'num_mask_voxels {num_mask_voxels}', file=logfile, flush=True)
 
@@ -112,20 +112,17 @@ summary('unfold_gz',unfold_gz)
 interp_ap = griddata(points,
                         values=native_coords_phys[:,0],
                         xi=unfold_xi,
-                        method=interp_method,fill_value=0)
-
-
+                        method=interp_method)
 summary('interp_ap',interp_ap)
 interp_pd = griddata(points,
                         values=native_coords_phys[:,1],
                         xi=unfold_xi,
-                        method=interp_method,fill_value=0)
+                        method=interp_method)
 summary('interp_pd',interp_pd)
 interp_io = griddata(points,
                         values=native_coords_phys[:,2],
                         xi=unfold_xi,
-                        method=interp_method,fill_value=0)
-
+                        method=interp_method)
 summary('interp_io',interp_ap)
 
 
@@ -136,6 +133,8 @@ mapToNative = np.zeros(unfold_grid_phys.shape)
 mapToNative[:,:,:,0,0] = interp_ap
 mapToNative[:,:,:,0,1] = interp_pd
 mapToNative[:,:,:,0,2] = interp_io
+# TODO: interpolate nans more better
+mapToNative[np.isnan(mapToNative)] = 0
 summary('mapToNative',mapToNative)
 
 # mapToNative has the absolute coordinates, but we want them relative to the 

--- a/hippunfold/workflow/scripts/create_warps.py
+++ b/hippunfold/workflow/scripts/create_warps.py
@@ -96,7 +96,11 @@ summary('unfold_grid_phys',unfold_grid_phys)
 # we have points defined by coord_flat_{ap,pd,io}, and corresponding value as native_coords_phys[:,i]
 # and we want to interpolate on a grid in the unfolded space
 
-points = (coord_flat_ap,coord_flat_pd,coord_flat_io)
+# add some noise to avoid perfectly overlapping datapoints!
+points = (coord_flat_ap + (np.random.rand(coord_flat_ap.shape[0])-0.5)*1e-6,
+    coord_flat_pd + (np.random.rand(coord_flat_ap.shape[0])-0.5)*1e-6,
+    coord_flat_io + (np.random.rand(coord_flat_ap.shape[0])-0.5)*1e-6)
+
 # get unfolded grid (from 0 to 1, not world coords), using meshgrid:
 #  note: indexing='ij' to swap the ordering of x and y 
 (unfold_gx, unfold_gy, unfold_gz) = np.meshgrid(np.linspace(0,1,unfold_dims[0]),

--- a/hippunfold/workflow/scripts/create_warps.py
+++ b/hippunfold/workflow/scripts/create_warps.py
@@ -112,19 +112,19 @@ summary('unfold_gz',unfold_gz)
 interp_ap = griddata(points,
                         values=native_coords_phys[:,0],
                         xi=unfold_xi,
-                        method=interp_method)
+                        method=interp_method,fill_value=0)
 
 
 summary('interp_ap',interp_ap)
 interp_pd = griddata(points,
                         values=native_coords_phys[:,1],
                         xi=unfold_xi,
-                        method=interp_method)
+                        method=interp_method,fill_value=0)
 summary('interp_pd',interp_pd)
 interp_io = griddata(points,
                         values=native_coords_phys[:,2],
                         xi=unfold_xi,
-                        method=interp_method)
+                        method=interp_method,fill_value=0)
 
 summary('interp_io',interp_ap)
 
@@ -145,13 +145,16 @@ summary('dispacementToNative',displacementToNative)
 
 
 # write to file
-warp_unfold2native_nib = nib.Nifti1Image(displacementToNative,
+dt = unfold_phys_coords_nib.get_fdata()
+dt = dt.dtype.name
+warp_unfold2native_nib = nib.Nifti1Image(displacementToNative.astype(dt),
                                         unfold_phys_coords_nib.affine,
                                         unfold_phys_coords_nib.header)
 warp_unfold2native_nib.to_filename(snakemake.output.warp_unfold2native)
 
 # write itk transform to file
-warpitk_native2unfold_nib = nib.Nifti1Image(convert_warp_to_itk(displacementToNative),
+f = convert_warp_to_itk(displacementToNative)
+warpitk_native2unfold_nib = nib.Nifti1Image(f.astype(dt),
                                         unfold_phys_coords_nib.affine,
                                         unfold_phys_coords_nib.header)
 
@@ -219,13 +222,16 @@ for d in range(3):
 summary('native_to_unfold',native_to_unfold)
 
 #now, can write it to file
-warp_native2unfold_nib = nib.Nifti1Image(native_to_unfold,
+dt = coord_ap_nib.get_fdata()
+dt = dt.dtype.name
+warp_native2unfold_nib = nib.Nifti1Image(native_to_unfold.astype(dt),
                                         coord_ap_nib.affine,
                                         coord_ap_nib.header)
 warp_native2unfold_nib.to_filename(snakemake.output.warp_native2unfold)
 
 #and save ITK warp too
-warpitk_unfold2native_nib = nib.Nifti1Image(convert_warp_to_itk(native_to_unfold),
+f = convert_warp_to_itk(native_to_unfold)
+warpitk_unfold2native_nib = nib.Nifti1Image(f.astype(dt),
                                         coord_ap_nib.affine,
                                         coord_ap_nib.header)
 warpitk_unfold2native_nib.to_filename(snakemake.output.warpitk_unfold2native)

--- a/hippunfold/workflow/scripts/create_warps.py
+++ b/hippunfold/workflow/scripts/create_warps.py
@@ -34,7 +34,7 @@ coord_pd = coord_pd_nib.get_fdata()
 coord_io = coord_io_nib.get_fdata()
 
 #get mask of coords  (note: this leaves out coord=0)
-mask = (coord_ap > 0) & (coord_pd > 0) & (coord_io > 0) # matlab: mask = (coord_ap>0 & coord_pd>0 & coord_io>0);
+mask = (coord_ap > 0) | (coord_pd > 0) | (coord_io > 0) # some points were lost, especially IO
 num_mask_voxels = np.sum(mask>0)
 print(f'num_mask_voxels {num_mask_voxels}')
 

--- a/hippunfold/workflow/scripts/create_warps.py
+++ b/hippunfold/workflow/scripts/create_warps.py
@@ -68,9 +68,9 @@ summary('native_coords_mat',native_coords_mat)
 
 
 #... then,apply native image affine to get world coords ...
-
+aff = coord_ap_nib.affine
 print(f'affine: {aff}, affine shape: {aff.shape}', file=logfile, flush=True)
-native_coords_phys = coord_ap_nib.affine @ native_coords_mat
+native_coords_phys = aff @ native_coords_mat
 native_coords_phys = np.transpose(native_coords_phys[:3,:])
 summary('native_coords_phys',native_coords_phys)
 

--- a/hippunfold/workflow/scripts/mapUnfoldToFullGrid.sh
+++ b/hippunfold/workflow/scripts/mapUnfoldToFullGrid.sh
@@ -23,10 +23,9 @@ fill_val=-1
 
 pad_cmd="-pad 32x32x32vox 32x32x32vox $fill_val"
 
-
-N_AP=256
-N_PD=128
-N_IO=16
+N_AP=$6
+N_PD=$7
+N_IO=$8
 
 
 in_warpitk_native2unfold=${warps_dir}/WarpITK_native2unfold.nii

--- a/hippunfold/workflow/scripts/mapUnfoldToFullGrid.sh
+++ b/hippunfold/workflow/scripts/mapUnfoldToFullGrid.sh
@@ -11,10 +11,13 @@ coords_PD=$2
 coords_IO=$3
 in_unfold_ref=$4
 warps_dir=$5
+N_AP=$6
+N_PD=$7
+N_IO=$8
 
-if [ "$#" -lt 5 ]
+if [ "$#" -lt 8 ]
 then
-    echo "Usage: $0 coords_ap coords_pd coords_io unfold_ref out_warps_dir"
+    echo "Usage: $0 coords_ap coords_pd coords_io unfold_ref out_warps_dir N_AP N_PD N_IO"
     exit 1
 fi
 
@@ -22,10 +25,6 @@ fi
 fill_val=-1
 
 pad_cmd="-pad 32x32x32vox 32x32x32vox $fill_val"
-
-N_AP=$6
-N_PD=$7
-N_IO=$8
 
 
 in_warpitk_native2unfold=${warps_dir}/WarpITK_native2unfold.nii


### PR DESCRIPTION
After spending a long time trying to get this step (and the next) to work on 3D PLI and BigBrain data at super high resolution, I realized the issue wasn't memory. I'll leave https://github.com/khanlab/hippunfold/tree/create_warps_resource_manage as is in case we need further memory management (in this case by downsampling) in the future.

The actual issue is outlined here:
https://stackoverflow.com/questions/10886971/alternatives-to-scipy-interpolate-griddata-that-dont-hang-on-aligned-points

The solution is to simply add a tiny bit of noise to the Laplace coords to ensure none of them are perfectly overlapping or perfectly aligned along any one dimension. I'm keeping some of the improvements and debugging from the downsampling code since this step still takes ~1h and its nice to check that it is indeed running. 