### PR TITLE
bugfix: pin version of batchgenerators

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setuptools.setup(
     install_requires=[
         "snakebids>=0.3.10",
         "snakemake>=6.5.2",
+        "batchgenerators==0.21",
         "nnunet-inference-on-cpu-and-gpu==1.6.6",
         "numpy>=1.20.2",
         "astropy",


### PR DESCRIPTION
upgrade of batchgenerators to 0.23 (or maybe 0.22 even) breaks our code.. pinning to 0.21 for now..

  
```
ImportError: cannot import name 'MultiThreadedAugmenter' from 'batchgenerators.dataloading' (/srv/khan/users/alik/test_hippunfold/venv/lib/python3.8/site-packages/batchgenerators/dataloading/__init__.py)
```