### PR TITLE
adds coords on surfaces, & pre-smoothing for curv

### DIFF
--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -17,7 +17,7 @@ analysis_levels: &analysis_levels
 #mapping from analysis_level to set of target rules or files
 targets_by_analysis_level:
   participant:
-    - 'all'  # if '', then the first rule is run
+    - ''  # if '', then the first rule is run
   group:
     - 'all_group_tsv'
 
@@ -305,6 +305,10 @@ unfold_vol_ref:
     - '0'
     - '200'
     - '0'
+  extent:
+    - '40'
+    - '20'
+    - '2.5'
   orient: RPI
 
 #space for uniform unfolded grid 

--- a/hippunfold/workflow/rules/gifti.smk
+++ b/hippunfold/workflow/rules/gifti.smk
@@ -4,7 +4,6 @@ hemi_to_structure = {'L': 'CORTEX_LEFT', 'Lflip': 'CORTEX_LEFT', 'R': 'CORTEX_RI
 surf_to_secondary_type = {'midthickness': 'MIDTHICKNESS', 'inner': 'PIAL', 'outer': 'GRAY_WHITE'}
 
 
-
 rule warp_gii_unfoldtemplate2unfold: 
     """warp from template space to subj unfolded"""
     input: 
@@ -22,6 +21,40 @@ rule warp_gii_unfoldtemplate2unfold:
         'wb_command -surface-apply-warpfield {input.gii} {input.warp} {output.gii} && '
         'wb_command -set-structure {output.gii} {params.structure_type} -surface-type {params.surface_type}'
             ' -surface-secondary-type {params.secondary_type}'
+
+
+rule calc_unfold_template_coords:
+    """ Creates a coords.shape.gii from the unfolded template """
+    input:
+        midthickness_gii = os.path.join(config['snakemake_dir'],'resources','unfold_template','tpl-avg_space-unfold_den-{density}_midthickness.surf.gii')
+    params:
+        coords_xyz = 'coords-XYZ.shape.gii',
+        coord_AP = 'coord-AP.shape.gii',
+        coord_PD = 'coord-PD.shape.gii',
+        coord_IO = 'coord-IO.shape.gii',
+        origin = config['unfold_vol_ref']['origin'],
+        extent = config['unfold_vol_ref']['extent'],
+        structure_type = lambda wildcards: hemi_to_structure[wildcards.hemi],
+    output:
+        coords_gii = bids(root='work',datatype='surf_{modality}',den='{density}',suffix='coords.shape.gii', space='{space}',hemi='{hemi}', **config['subj_wildcards']),
+    shadow: 'minimal' #this is required to use the temporary files defined as params
+    shell:
+        "wb_command -surface-coordinates-to-metric {input.midthickness_gii} {params.coords_xyz} && "
+        "wb_command -file-information {params.coords_xyz} && "
+        "wb_command -metric-math '({params.origin[0]}-X)/{params.extent[0]}' {params.coord_AP} -var X {params.coords_xyz} -column 1 && "
+        "wb_command -file-information {params.coord_AP} && "
+        "wb_command -metric-math '({params.origin[1]}+Y)/{params.extent[1]}' {params.coord_PD} -var Y {params.coords_xyz} -column 2 && "
+        "wb_command -file-information {params.coord_PD} && "
+        "wb_command -metric-math '({params.origin[2]}+Z)/{params.extent[2]}' {params.coord_IO} -var Z {params.coords_xyz} -column 3 && "
+        "wb_command -file-information {params.coord_IO} && "
+        "wb_command -metric-merge {output.coords_gii}  -metric {params.coord_AP} -metric {params.coord_PD} -metric {params.coord_IO} && "
+        "wb_command -set-structure {output.coords_gii} {params.structure_type}"
+
+       
+        
+   
+
+    
 
 #subj unfolded surf might have a few vertices outside the bounding box.. this constrains all the vertices to the warp bounding box
 rule constrain_surf_to_bbox:
@@ -141,9 +174,24 @@ rule calculate_gyrification:
             ' -var nativearea {input.native_surfarea} -var unfoldarea {input.unfold_surfarea}'
 
 
+rule smooth_surface:
+    input:
+        gii = bids(root='results',datatype='surf_{modality}',den='{density}',suffix='midthickness.surf.gii', space='{space}',hemi='{hemi}', **config['subj_wildcards'])
+    params:
+        strength = 0.6,
+        iterations = 100
+    output:
+        gii = bids(root='results',datatype='surf_{modality}',den='{density}',suffix='midthickness.surf.gii', space='{space}',hemi='{hemi}', desc='smoothed',**config['subj_wildcards'])
+    container: config['singularity']['autotop']
+    group: 'subj' 
+    shell:
+        "wb_command -surface-smoothing {input.gii} {params.strength} {params.iterations} {output.gii}"
+
+    
+
 rule calculate_curvature_from_surface:
     input: 
-        gii = bids(root='results',datatype='surf_{modality}',den='{density}',suffix='midthickness.surf.gii', space='{space}',hemi='{hemi}', **config['subj_wildcards'])
+        gii = bids(root='results',datatype='surf_{modality}',den='{density}',suffix='midthickness.surf.gii', space='{space}',hemi='{hemi}', desc='smoothed',**config['subj_wildcards'])
     output:
         gii = bids(root='results',datatype='surf_{modality}',den='{density}',suffix='curvature.shape.gii', space='{space}',hemi='{hemi}', **config['subj_wildcards'])
     container: config['singularity']['autotop']
@@ -269,7 +317,7 @@ def get_cmd_spec_file(wildcards, input, output):
 rule create_spec_file:
     input:
         shapes = expand(bids(root='results',datatype='surf_{modality}',den='{density}',suffix='{shape}.shape.gii', space='{space}',hemi='{hemi}', **config['subj_wildcards']),
-                    shape=['gyrification','curvature','thickness'], allow_missing=True),
+                    shape=['gyrification','curvature','thickness','coords'], allow_missing=True),
         surfs = expand(bids(root='results',datatype='surf_{modality}',den='{density}',suffix='{surfname}.surf.gii', space='{space}', hemi='{hemi}', **config['subj_wildcards']),
                     surfname=['midthickness','inner','outer'], space=['{space}','unfolded'], allow_missing=True), 
         subfields = bids(root='results',datatype='surf_{modality}',den='{density}',suffix='subfields.label.gii', space='{space}',hemi='{hemi}', **config['subj_wildcards']),

--- a/hippunfold/workflow/rules/gifti.smk
+++ b/hippunfold/workflow/rules/gifti.smk
@@ -37,6 +37,7 @@ rule calc_unfold_template_coords:
         structure_type = lambda wildcards: hemi_to_structure[wildcards.hemi],
     output:
         coords_gii = bids(root='work',datatype='surf_{modality}',den='{density}',suffix='coords.shape.gii', space='{space}',hemi='{hemi}', **config['subj_wildcards']),
+    container: config['singularity']['autotop']
     shadow: 'minimal' #this is required to use the temporary files defined as params
     shell:
         "wb_command -surface-coordinates-to-metric {input.midthickness_gii} {params.coords_xyz} && "


### PR DESCRIPTION
Unfolded coords now generated as a surface metric too, is especially needed if using surfaces other than 32k.

Also added smoothing to mid-surface prior to curvature calculation (thanks @Bradley-Karat for testing out parameters for this step)

Unrelated: Fixed config yml issue that always added rule 'all', even if target rule specified from command-line

- [x] initial testing of the rules
- [x] run entire workflow on a subject and examine results