### PR TITLE
added missing group directive

### DIFF
--- a/hippunfold/workflow/rules/gifti.smk
+++ b/hippunfold/workflow/rules/gifti.smk
@@ -39,6 +39,7 @@ rule calc_unfold_template_coords:
         coords_gii = bids(root='work',datatype='surf_{modality}',den='{density}',suffix='coords.shape.gii', space='{space}',hemi='{hemi}', **config['subj_wildcards']),
     container: config['singularity']['autotop']
     shadow: 'minimal' #this is required to use the temporary files defined as params
+    group: 'subj'
     shell:
         "wb_command -surface-coordinates-to-metric {input.midthickness_gii} {params.coords_xyz} && "
         "wb_command -file-information {params.coords_xyz} && "


### PR DESCRIPTION
bugfix: 
rule `calc_unfold_template_coords` was missing group directive, would cause issues if cc-slurm profile was used..