### PR TITLE
minor fix to template shape injection

### DIFF
--- a/hippunfold/workflow/rules/shape_inject.smk
+++ b/hippunfold/workflow/rules/shape_inject.smk
@@ -44,7 +44,9 @@ def get_image_pairs(wildcards, input):
 
 
     args = []
-    for label in config['shape_inject']['labels_reg']:
+    #prep_segs_for_greedy creates label_{i} images for each entry in labels_reg, 
+    # but the numbering will be from 1 to N (not the numbers in the list)
+    for label in range(1,len(config['shape_inject']['labels_reg'])+1): 
         subject_label = f'{input.subject_seg}/label_{label:02d}.nii.gz'
         template_label = f'{input.template_seg}/label_{label:02d}.nii.gz'
 


### PR DESCRIPTION
This fixes a minor bug in template shape injection. The nnunet segmentation is split into channels, and those channels are used for registration when doing template injection. The segmentation labels we retain are specified in a config (e.g. to skip the cyst label, 7).  The bug is that the code was assuming the channel indices in the split images (i.e.. label_##.nii.gz) were as they are in that config list (ie. 1-6,8) but the splitting process always writes them as 1-N (where N is the number of labels retained). So it ended up looking for label 8 instead of label 7, which is always missing, so the dentate doesn't end up getting used in the registration.

I think this is a pretty minor fix that probably won't change the resulting segmentation that much (since adding one channel to the multi-channel registration isn't going to have a huge effect). The nice thing is we won't see the warning message that label_08 doesn't exist anymore (which was what caught my attention in the first place).. 

