### PR TITLE
fixes to get group analysis_level working again

### DIFF
--- a/hippunfold/workflow/Snakefile
+++ b/hippunfold/workflow/Snakefile
@@ -146,11 +146,13 @@ rule all_group_tsv:
     input:
         tsv=expand(
             bids(
-                root="results",
+                root=root,
                 prefix="group",
                 from_="{modality}",
                 desc="subfields",
+                space="{space}",
                 suffix="volumes.tsv",
             ),
             modality=config["modality"],
+            space=crop_ref_spaces,
         ),

--- a/hippunfold/workflow/rules/qc.smk
+++ b/hippunfold/workflow/rules/qc.smk
@@ -211,6 +211,7 @@ rule qc_subfield_surf:
         "../scripts/vis_qc_surf.py"
 
 
+
 rule concat_subj_vols_tsv:
     """Concatenate all subject tsv files into a single tsv"""
     input:
@@ -219,6 +220,7 @@ rule concat_subj_vols_tsv:
                 root=root,
                 datatype="anat",
                 desc="subfields",
+                space="{space}",
                 suffix="volumes.tsv",
                 **config["subj_wildcards"]
             ),
@@ -226,11 +228,19 @@ rule concat_subj_vols_tsv:
                 "subject"
             ],
             session=config["sessions"],
+            space=wildcards.space,
         ),
     group:
         "aggregate"
     output:
-        tsv=bids(root=root, prefix="group", desc="subfields", suffix="volumes.tsv"),
+        tsv=bids(
+            root=root,
+            prefix="group",
+            space="{space}",
+            from_="{modality}",
+            desc="subfields",
+            suffix="volumes.tsv",
+        ),
     run:
         import pandas as pd
 

--- a/hippunfold/workflow/rules/qc.smk
+++ b/hippunfold/workflow/rules/qc.smk
@@ -211,7 +211,6 @@ rule qc_subfield_surf:
         "../scripts/vis_qc_surf.py"
 
 
-
 rule concat_subj_vols_tsv:
     """Concatenate all subject tsv files into a single tsv"""
     input:


### PR DESCRIPTION
Group stage produces a tsv file with volumes from volumetric subfield seg with all subjects. Was not working since the v1.0.0 refactoring, this PR fixes the naming to get it working again.. 

Should think about also adding some additional TSV files from surface-based data, e.g.: thickness, gyrification, surface area, etc in each subfield + DG in another PR