### PR TITLE
upgrade to autotop_deps v0.4.2 - python 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM khanlab/autotop_deps:v0.4.1
+FROM khanlab/autotop_deps:v0.4.2
 
 MAINTAINER alik@robarts.ca
 


### PR DESCRIPTION
should fix singularity deployment errors that arose recently