### PR TITLE
bugfix for warps hemi-L

### DIFF
--- a/hippunfold/workflow/rules/gifti.smk
+++ b/hippunfold/workflow/rules/gifti.smk
@@ -28,7 +28,7 @@ rule cp_template_to_unfold:
             den="{density}",
             suffix="{surfname}.surf.gii",
             space="unfolded",
-            hemi="{hemi,R|Lflip}",
+            hemi="{hemi}",
             label="{autotop}",
             **config["subj_wildcards"]
         ),
@@ -176,7 +176,7 @@ rule warp_gii_unfold2native:
             suffix="{surfname}.surf.gii",
             desc="nonancorrect",
             space="corobl",
-            hemi="{hemi,R|Lflip}",
+            hemi="{hemi}",
             label="{autotop}",
             **config["subj_wildcards"]
         ),
@@ -211,7 +211,7 @@ rule correct_nan_vertices:
             den="{density}",
             suffix="{surfname}.surf.gii",
             space="corobl",
-            hemi="{hemi,R|Lflip}",
+            hemi="{hemi}",
             label="{autotop,hipp|dentate}",
             **config["subj_wildcards"]
         ),
@@ -219,101 +219,6 @@ rule correct_nan_vertices:
         "subj"
     script:
         "../scripts/fillnanvertices.py"
-
-
-# unflip surface
-rule unflip_gii:
-    input:
-        gii=bids(
-            root=work,
-            datatype="surf",
-            den="{density}",
-            suffix="{surfname}.surf.gii",
-            space="corobl",
-            hemi="{hemi}flip",
-            label="{autotop}",
-            **config["subj_wildcards"]
-        ),
-    params:
-        structure_type=lambda wildcards: hemi_to_structure[wildcards.hemi],
-        secondary_type=lambda wildcards: surf_to_secondary_type[wildcards.surfname],
-        surface_type="ANATOMICAL",
-    output:
-        gii=bids(
-            root=work,
-            datatype="surf",
-            den="{density}",
-            suffix="{surfname}.surf.gii",
-            space="corobl",
-            hemi="{hemi,L}",
-            label="{autotop}",
-            **config["subj_wildcards"]
-        ),
-    container:
-        config["singularity"]["autotop"]
-    group:
-        "subj"
-    shell:
-        "wb_command -surface-flip-lr {input.gii} {output.gii} && "
-        "wb_command -set-structure {output.gii} {params.structure_type} -surface-type {params.surface_type}"
-        " -surface-secondary-type {params.secondary_type}"
-
-
-def get_unfolded_surf_R_Lflip(wildcards):
-    if wildcards.hemi == "R":
-        return bids(
-            root=work,
-            datatype="surf",
-            den="{density}",
-            suffix="{surfname}.surf.gii",
-            space="unfolded",
-            hemi="{hemi}",
-            label="{autotop}",
-            **config["subj_wildcards"]
-        ).format(**wildcards)
-    elif wildcards.hemi == "L":
-        return bids(
-            root=work,
-            datatype="surf",
-            den="{density}",
-            suffix="{surfname}.surf.gii",
-            space="unfolded",
-            hemi="{hemi}flip",
-            label="{autotop}",
-            **config["subj_wildcards"]
-        ).format(**wildcards)
-
-
-rule unflip_gii_unfolded:
-    """copy unfolded from Lflip to L"""
-    input:
-        gii=bids(
-            root=work,
-            datatype="surf",
-            den="{density}",
-            suffix="{surfname}.surf.gii",
-            space="unfolded",
-            hemi="{hemi}flip",
-            label="{autotop}",
-            **config["subj_wildcards"]
-        ),
-    output:
-        gii=bids(
-            root=work,
-            datatype="surf",
-            den="{density}",
-            suffix="{surfname}.surf.gii",
-            space="unfolded",
-            hemi="{hemi,L}",
-            label="{autotop}",
-            **config["subj_wildcards"]
-        ),
-    container:
-        config["singularity"]["autotop"]
-    group:
-        "subj"
-    shell:
-        "cp {input.gii} {output.gii}"
 
 
 # warp from corobl to native

--- a/hippunfold/workflow/rules/shape_inject.smk
+++ b/hippunfold/workflow/rules/shape_inject.smk
@@ -320,7 +320,7 @@ rule inject_init_laplace_coords:
             suffix="coords.nii.gz",
             desc="init",
             space="corobl",
-            hemi="{hemi}"
+            hemi="{hemi,R|Lflip}"
         ),
     log:
         bids(
@@ -330,7 +330,7 @@ rule inject_init_laplace_coords:
             label="{autotop}",
             suffix="injectcoords.txt",
             desc="init",
-            hemi="{hemi}"
+            hemi="{hemi,R|Lflip}"
         ),
     group:
         "subj"

--- a/hippunfold/workflow/rules/warps.smk
+++ b/hippunfold/workflow/rules/warps.smk
@@ -349,7 +349,6 @@ rule create_warps_dentate:
         "../scripts/create_warps.py"
 
 
-
 rule compose_warps_native_to_unfold:
     """ Compose warps from native to unfold """
     input:

--- a/hippunfold/workflow/rules/warps.smk
+++ b/hippunfold/workflow/rules/warps.smk
@@ -176,7 +176,7 @@ rule create_warps_hipp:
             **config["subj_wildcards"],
             label="hipp",
             suffix="xfm.nii.gz",
-            hemi="{hemi,Lflip|R}",
+            hemi="{hemi}",
             from_="unfold",
             to="corobl",
             mode="surface"
@@ -187,7 +187,7 @@ rule create_warps_hipp:
             **config["subj_wildcards"],
             label="hipp",
             suffix="xfm.nii.gz",
-            hemi="{hemi,Lflip|R}",
+            hemi="{hemi}",
             from_="corobl",
             to="unfold",
             mode="surface"
@@ -198,7 +198,7 @@ rule create_warps_hipp:
             **config["subj_wildcards"],
             label="hipp",
             suffix="xfm.nii.gz",
-            hemi="{hemi,Lflip|R}",
+            hemi="{hemi}",
             from_="unfold",
             to="corobl",
             mode="image"
@@ -209,7 +209,7 @@ rule create_warps_hipp:
             **config["subj_wildcards"],
             label="hipp",
             suffix="xfm.nii.gz",
-            hemi="{hemi,Lflip|R}",
+            hemi="{hemi}",
             from_="corobl",
             to="unfold",
             mode="image"
@@ -220,7 +220,7 @@ rule create_warps_hipp:
         bids(
             root="logs",
             **config["subj_wildcards"],
-            hemi="{hemi,Lflip|R}",
+            hemi="{hemi}",
             suffix="create_warps-hipp.txt"
         ),
     script:
@@ -251,7 +251,7 @@ rule create_warps_dentate:
             dir="AP",
             label="dentate",
             suffix="coords.nii.gz",
-            desc="init",
+            desc="laplace",
             space="corobl",
             hemi="{hemi}",
             **config["subj_wildcards"]
@@ -262,7 +262,7 @@ rule create_warps_dentate:
             dir="PD",
             label="dentate",
             suffix="coords.nii.gz",
-            desc="init",
+            desc="laplace",
             space="corobl",
             hemi="{hemi}",
             **config["subj_wildcards"]
@@ -273,7 +273,7 @@ rule create_warps_dentate:
             dir="IO",
             label="dentate",
             suffix="coords.nii.gz",
-            desc="init",
+            desc="laplace",
             space="corobl",
             hemi="{hemi}",
             **config["subj_wildcards"]
@@ -298,7 +298,7 @@ rule create_warps_dentate:
             **config["subj_wildcards"],
             label="dentate",
             suffix="xfm.nii.gz",
-            hemi="{hemi,Lflip|R}",
+            hemi="{hemi}",
             from_="unfold",
             to="corobl",
             mode="surface"
@@ -309,7 +309,7 @@ rule create_warps_dentate:
             **config["subj_wildcards"],
             label="dentate",
             suffix="xfm.nii.gz",
-            hemi="{hemi,Lflip|R}",
+            hemi="{hemi}",
             from_="corobl",
             to="unfold",
             mode="surface"
@@ -320,7 +320,7 @@ rule create_warps_dentate:
             **config["subj_wildcards"],
             label="dentate",
             suffix="xfm.nii.gz",
-            hemi="{hemi,Lflip|R}",
+            hemi="{hemi}",
             from_="unfold",
             to="corobl",
             mode="image"
@@ -331,7 +331,7 @@ rule create_warps_dentate:
             **config["subj_wildcards"],
             label="dentate",
             suffix="xfm.nii.gz",
-            hemi="{hemi,Lflip|R}",
+            hemi="{hemi}",
             from_="corobl",
             to="unfold",
             mode="image"
@@ -342,135 +342,12 @@ rule create_warps_dentate:
         bids(
             root="logs",
             **config["subj_wildcards"],
-            hemi="{hemi,Lflip|R}",
+            hemi="{hemi}",
             suffix="create_warps-dentate.txt"
         ),
     script:
         "../scripts/create_warps.py"
 
-
-rule compose_warps_corobl2unfold_lhemi:
-    """ Compose corobl to unfold (unfold-template), for left hemi (ie with flip)"""
-    input:
-        native2unfold=bids(
-            root=work,
-            datatype="warps",
-            **config["subj_wildcards"],
-            label="{autotop}",
-            suffix="xfm.nii.gz",
-            hemi="Lflip",
-            from_="corobl",
-            to="unfold",
-            mode="image"
-        ),
-        ref=bids(
-            root=work,
-            space="unfold",
-            label="{autotop}",
-            datatype="warps",
-            suffix="refvol.nii.gz",
-            **config["subj_wildcards"]
-        ),
-        flipLR_xfm=os.path.join(
-            workflow.basedir, "..", "resources", "desc-flipLR_type-itk_xfm.txt"
-        ),
-    output:
-        corobl2unfold=bids(
-            root=work,
-            datatype="warps",
-            **config["subj_wildcards"],
-            label="{autotop}",
-            suffix="xfm.nii.gz",
-            hemi="L",
-            from_="corobl",
-            to="unfold",
-            mode="image"
-        ),
-    log:
-        bids(
-            root="logs",
-            **config["subj_wildcards"],
-            label="{autotop}",
-            suffix="composexfm.txt",
-            hemi="L",
-            from_="corobl",
-            to="unfold",
-            mode="image"
-        ),
-    container:
-        config["singularity"]["autotop"]
-    group:
-        "subj"
-    shell:
-        "ComposeMultiTransform 3 {output.corobl2unfold} -R {input.ref} {input.native2unfold} {input.flipLR_xfm} &> {log}"
-
-
-# consider renaming to state this composition is to "un-flip"
-rule compose_warps_unfold2corobl_lhemi:
-    """ Compose unfold (unfold-template) to corobl, for left hemi (ie with flip)"""
-    input:
-        unfold2native=bids(
-            root=work,
-            datatype="warps",
-            **config["subj_wildcards"],
-            label="{autotop}",
-            suffix="xfm.nii.gz",
-            hemi="Lflip",
-            from_="unfold",
-            to="corobl",
-            mode="image"
-        ),
-        flipLR_xfm=os.path.join(
-            workflow.basedir, "..", "resources", "desc-flipLR_type-itk_xfm.txt"
-        ),
-        unfold_ref=bids(
-            root=work,
-            space="unfold",
-            label="{autotop}",
-            datatype="warps",
-            suffix="refvol.nii.gz",
-            **config["subj_wildcards"]
-        ),
-        ref=bids(
-            root=work,
-            datatype="coords",
-            dir="AP",
-            label="{autotop}",
-            suffix="coords.nii.gz",
-            desc="laplace",
-            space="corobl",
-            hemi="L",
-            **config["subj_wildcards"]
-        ),
-    output:
-        unfold2corobl=bids(
-            root=work,
-            datatype="warps",
-            **config["subj_wildcards"],
-            label="{autotop}",
-            suffix="xfm.nii.gz",
-            hemi="L",
-            from_="unfold",
-            to="corobl",
-            mode="image"
-        ),
-    log:
-        bids(
-            root="logs",
-            **config["subj_wildcards"],
-            label="{autotop}",
-            suffix="composexfm.txt",
-            hemi="L",
-            from_="unfold",
-            to="corobl",
-            mode="image"
-        ),
-    container:
-        config["singularity"]["ants"]
-    group:
-        "subj"
-    shell:
-        "antsApplyTransforms -o [{output.unfold2corobl},1] -r {input.ref} -t {input.flipLR_xfm} -t {input.unfold2native} -i {input.unfold_ref} -v &> {log}"
 
 
 rule compose_warps_native_to_unfold:


### PR DESCRIPTION
I noticed there were still some issues with the warps `from-unfold_to-native`. I think this can be solved and the code simplified by simply running create_warps AFTER unflipping. 

For the record, i think there is a difference between concatenating `desc-flipLR_type-itk_xfm.txt` onto existing transforms and flipping with `c3d -flip x`. I think one of these applies to the header only, while the other applied to the actual image. These should be equivalent, but i don't think that ANTs reads them the same way. Either way, this circumvents the issue entirely. 

I tested once for a standard T1w modality and once for a cropseg modality (where output space is corobl) and both seem to work.