### PR TITLE
update release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -7,6 +7,7 @@ template: |
 categories:
   - title: '🚀 Features'
     labels:
+      - 'major'
       - 'breaking'
       - 'enhancement'
   - title: '🐛 Bug Fixes'
@@ -29,9 +30,10 @@ change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add
 version-resolver:
   major:
     labels:
-      - 'breaking'
+      - 'major'
   minor:
     labels:
+      - 'breaking'
       - 'enhancement'
   patch:
     labels:


### PR DESCRIPTION
adds major-breaking change label, otherwise uses minor- otherwise would be at 2.0.0 with next breaking change.. 