### PR TITLE
bugfix: subfields label.gii wasn't being generated properly

### DIFF
--- a/hippunfold/workflow/rules/gifti.smk
+++ b/hippunfold/workflow/rules/gifti.smk
@@ -516,6 +516,11 @@ rule nii_to_label_gii:
             "unfold_template_hipp",
             "tpl-avg_space-unfold_den-{density}_midthickness.surf.gii",
         ),
+        label_list=lambda wildcards: os.path.join(
+            workflow.basedir, "..", config["atlas_files"][wildcards.atlas]["label_list"]
+        ),
+    params:
+        structure_type=lambda wildcards: hemi_to_structure[wildcards.hemi],
     output:
         label_gii=bids(
             root=root,
@@ -530,10 +535,14 @@ rule nii_to_label_gii:
         ),
     group:
         "subj"
+    shadow: "minimal"
     container:
         config["singularity"]["autotop"]
     shell:
-        "wb_command -volume-to-surface-mapping {input.label_nii} {input.surf} {output.label_gii} -enclosing"
+        "wb_command -volume-to-surface-mapping {input.label_nii} {input.surf} temp.shape.gii -enclosing  && "
+        "wb_command -metric-label-import temp.shape.gii {input.label_list} {output.label_gii} && "
+        "wb_command -set-structure {output.label_gii} {params.structure_type}"
+
 
 
 def get_cmd_cifti_metric(wildcards, input, output):
@@ -739,7 +748,7 @@ rule create_spec_file_hipp:
             space=["{space}", "unfolded"],
             allow_missing=True,
         ),
-        cifti=lambda wildcards: expand(
+        cifti_metrics=lambda wildcards: expand(
             bids(
                 root=root,
                 datatype="surf",
@@ -752,6 +761,21 @@ rule create_spec_file_hipp:
             cifti=get_cifti_metric_types(wildcards.label),
             allow_missing=True,
         ),
+        cifti_labels=lambda wildcards: expand(
+            bids(
+                root=root,
+                datatype="surf",
+                den="{density}",
+                suffix="subfields.dlabel.nii",
+                atlas="{atlas}",
+                space="{space}",
+                label="{label}",
+                **config["subj_wildcards"]
+            ),
+            atlas=config["atlas"],
+            allow_missing=True,
+        ),
+
     params:
         cmds=get_cmd_spec_file,
     output:

--- a/hippunfold/workflow/rules/gifti.smk
+++ b/hippunfold/workflow/rules/gifti.smk
@@ -517,7 +517,9 @@ rule nii_to_label_gii:
             "tpl-avg_space-unfold_den-{density}_midthickness.surf.gii",
         ),
         label_list=lambda wildcards: os.path.join(
-            workflow.basedir, "..", config["atlas_files"][wildcards.atlas]["label_list"]
+            workflow.basedir,
+            "..",
+            config["atlas_files"][wildcards.atlas]["label_list"],
         ),
     params:
         structure_type=lambda wildcards: hemi_to_structure[wildcards.hemi],
@@ -535,14 +537,14 @@ rule nii_to_label_gii:
         ),
     group:
         "subj"
-    shadow: "minimal"
+    shadow:
+        "minimal"
     container:
         config["singularity"]["autotop"]
     shell:
         "wb_command -volume-to-surface-mapping {input.label_nii} {input.surf} temp.shape.gii -enclosing  && "
         "wb_command -metric-label-import temp.shape.gii {input.label_list} {output.label_gii} && "
         "wb_command -set-structure {output.label_gii} {params.structure_type}"
-
 
 
 def get_cmd_cifti_metric(wildcards, input, output):
@@ -775,7 +777,6 @@ rule create_spec_file_hipp:
             atlas=config["atlas"],
             allow_missing=True,
         ),
-
     params:
         cmds=get_cmd_spec_file,
     output:


### PR DESCRIPTION
bug introduced in a recent PR, had to convert the metric gii to a label gii after volume-to-surface-mapping