### PR TITLE
Added missing container for hippdwi_to_template

### DIFF
--- a/hippunfold/workflow/rules/preproc_hippb500.smk
+++ b/hippunfold/workflow/rules/preproc_hippb500.smk
@@ -21,6 +21,8 @@ rule resample_hippdwi_to_template:
             suffix="b500.nii.gz",
             **config["subj_wildcards"]
         ),
+    container:
+        config["singularity"]["autotop"]
     group:
         "subj"
     shell:


### PR DESCRIPTION
This PR adds the `autotop` container to fix the missing command error for `c3d` when the `hippdwi_to_template` rule is run.

Resolves #215 