### PR TITLE
aligns laplace_coords.py behaviour to laplace_coords_withinit.py

### DIFF
--- a/hippunfold/workflow/scripts/laplace_coords.py
+++ b/hippunfold/workflow/scripts/laplace_coords.py
@@ -84,7 +84,7 @@ for i in range(max_iters):
     #       tonii[np.isnan(tonii)] = -1
     #       nib.Nifti1Image(tonii,lbl_nib.affine,lbl_nib.header).to_filename(f'debug_iter-{i:02d}.nii')
 
-    upd_coords = nan_convolve(coords, hl, preserve_nan=True)
+    upd_coords = nan_convolve(coords, hl, fill_value=np.nan, preserve_nan=True)
 
     upd_coords[source == 1] = 0
     upd_coords[sink == 1] = 1

--- a/hippunfold/workflow/scripts/laplace_coords.py
+++ b/hippunfold/workflow/scripts/laplace_coords.py
@@ -105,10 +105,7 @@ for i in range(max_iters):
 
     coords = upd_coords
 
-# remove any remaining NaNS
-coordsnonan = np.zeros_like(coords)
-coordsnonan[idxgm == 1] = coords[idxgm == 1]
-coordsnonan = np.nan_to_num(coordsnonan)
+coords[idxgm == 0] = np.nan  # setting outside GM to nan -- this was zero before..
 
 
 # save file

--- a/hippunfold/workflow/scripts/laplace_coords_withinit.py
+++ b/hippunfold/workflow/scripts/laplace_coords_withinit.py
@@ -63,7 +63,7 @@ for i in range(max_iters):
     #       tonii[np.isnan(tonii)] = -1
     #       nib.Nifti1Image(tonii,lbl_nib.affine,lbl_nib.header).to_filename(f'debug_iter-{i:02d}.nii')
 
-    upd_coords = nan_convolve(coords, hl, preserve_nan=True)
+    upd_coords = nan_convolve(coords, hl, fill_value=np.nan, preserve_nan=True)
 
     upd_coords[source == 1] = 0
     upd_coords[sink == 1] = 1


### PR DESCRIPTION
This was causing a bug where extra-hippocampal areas contained Laplace coordinates, which was messing up the mask generation in create_warps.py. This should fix that by setting all background labels back to NaN, and this is now in line with the behaviour of laplace_coords_withinit.py.