### PR TITLE
defined in mm instead of vox

### DIFF
--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -190,9 +190,15 @@ parse_args:
     default: false
     action: store_true
 
+  --crop_native_res:
+    help: 'Sets the bounding box resolution for the crop native (e.g. cropT1w space). Under the hood, hippUnfold operates at higher resolution than the native image, so this tries to preserve some of that detail. (default: %(default)s)'
+    default: '0.2x0.2x0.2mm'
+
   --crop_native_box:
-    help: 'Sets the bounding box size for the crop native (e.g. cropT1w) space). Make this larger if your hippocampi in crop{T1w,T2w} space are getting cut-off (default: %(default)s)'
+    help: 'Sets the bounding box size for the crop native (e.g. cropT1w space). Make this larger if your hippocampi in crop{T1w,T2w} space are getting cut-off (default: %(default)s)'
     default: '52x52x52mm'
+
+
 
   --atlas:
     choices:
@@ -387,6 +393,7 @@ nnunet_model:
   neonateT1w: trained_model.3d_fullres.Task205_hcp1200_b1000_finetuneround2_dhcp_T1w.nnUNetTrainerV2.model_best.tar
 
 crop_native_box: '52x52x52mm'
+crop_native_res: '0.2x0.2x0.2mm'
 
 hippdwi_opts:
   resample_dim: '734x720x67' # from 220x216x20 @ 1x1x1mm -> 0.3mm

--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -192,7 +192,7 @@ parse_args:
 
   --crop_native_box:
     help: 'Sets the bounding box size for the crop native (e.g. cropT1w) space). Make this larger if your hippocampi in crop{T1w,T2w} space are getting cut-off (default: %(default)s)'
-    default: '256x256x256vox'
+    default: '52x52x52mm'
 
   --atlas:
     choices:
@@ -386,7 +386,7 @@ nnunet_model:
   hippb500: trained_model.3d_fullres.Task110_hcp1200_b1000crop.nnUNetTrainerV2.model_best.tar
   neonateT1w: trained_model.3d_fullres.Task205_hcp1200_b1000_finetuneround2_dhcp_T1w.nnUNetTrainerV2.model_best.tar
 
-crop_native_box: '256x256x256vox'
+crop_native_box: '52x52x52mm'
 
 hippdwi_opts:
   resample_dim: '734x720x67' # from 220x216x20 @ 1x1x1mm -> 0.3mm

--- a/hippunfold/workflow/rules/resample_final_to_crop_native.smk
+++ b/hippunfold/workflow/rules/resample_final_to_crop_native.smk
@@ -17,7 +17,7 @@ rule create_native_crop_ref:
             allow_missing=True,
         ),
     params:
-        resample="400%",
+        resample=["crop_native_res"],
         pad_to=config["crop_native_box"],
     output:
         ref=bids(

--- a/hippunfold/workflow/rules/resample_final_to_crop_native.smk
+++ b/hippunfold/workflow/rules/resample_final_to_crop_native.smk
@@ -17,7 +17,7 @@ rule create_native_crop_ref:
             allow_missing=True,
         ),
     params:
-        resample=["crop_native_res"],
+        resample=config["crop_native_res"],
         pad_to=config["crop_native_box"],
     output:
         ref=bids(


### PR DESCRIPTION
this should be more robust to different input image resolutions. 52mm iso should be enough to cover the whole hippocampus.