### PR TITLE
fix bug in crop native box

### DIFF
--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -195,8 +195,8 @@ parse_args:
     default: '0.2x0.2x0.2mm'
 
   --crop_native_box:
-    help: 'Sets the bounding box size for the crop native (e.g. cropT1w space). Make this larger if your hippocampi in crop{T1w,T2w} space are getting cut-off (default: %(default)s)'
-    default: '52x52x52mm'
+    help: 'Sets the bounding box size for the crop native (e.g. cropT1w space). Make this larger if your hippocampi in crop{T1w,T2w} space are getting cut-off. This must be in voxels (vox) not millimeters (mm). (default: %(default)s)'
+    default: '256x256x256vox'
 
 
 
@@ -392,7 +392,7 @@ nnunet_model:
   hippb500: trained_model.3d_fullres.Task110_hcp1200_b1000crop.nnUNetTrainerV2.model_best.tar
   neonateT1w: trained_model.3d_fullres.Task205_hcp1200_b1000_finetuneround2_dhcp_T1w.nnUNetTrainerV2.model_best.tar
 
-crop_native_box: '52x52x52mm'
+crop_native_box: '256x256x256vox'
 crop_native_res: '0.2x0.2x0.2mm'
 
 hippdwi_opts:


### PR DESCRIPTION
This was being interpreted as 52x52x52vox instead of 52x52x52mm (could be a c3d bug or limitation in the `-pad-to` command. So had to change this back to voxel definition, 256x256x256vox. This is ok since at least the voxel resolution can be specified separately in mm.