### PR TITLE
T1T2w model file/url was missing from the config

### DIFF
--- a/hippunfold/config/nnunet_model_urls.yml
+++ b/hippunfold/config/nnunet_model_urls.yml
@@ -2,3 +2,4 @@ T1w: 'https://zenodo.org/record/4508747/files/trained_model.3d_fullres.Task101_h
 T2w: 'https://zenodo.org/record/4508747/files/trained_model.3d_fullres.Task102_hcp1200_T2w.nnUNetTrainerV2.model_best.tar'
 neonateT1w: 'https://zenodo.org/record/5733556/files/trained_model.3d_fullres.Task205_hcp1200_b1000_finetuneround2_dhcp_T1w.nnUNetTrainerV2.model_best.tar'
 hippb500: 'https://zenodo.org/record/5732291/files/trained_model.3d_fullres.Task110_hcp1200_b1000crop.nnUNetTrainerV2.model_best.tar'
+T1T2w: 'https://zenodo.org/record/4508747/files/trained_model.3d_fullres.Task103_hcp1200_T1T2w.nnUNetTrainerV2.model_best.tar'

--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -391,6 +391,7 @@ nnunet_model:
   T2w: trained_model.3d_fullres.Task102_hcp1200_T2w.nnUNetTrainerV2.model_best.tar
   hippb500: trained_model.3d_fullres.Task110_hcp1200_b1000crop.nnUNetTrainerV2.model_best.tar
   neonateT1w: trained_model.3d_fullres.Task205_hcp1200_b1000_finetuneround2_dhcp_T1w.nnUNetTrainerV2.model_best.tar
+  T1T2w: trained_model.3d_fullres.Task103_hcp1200_T1T2w.nnUNetTrainerV2.model_best.tar
 
 crop_native_box: '256x256x256vox'
 crop_native_res: '0.2x0.2x0.2mm'

--- a/hippunfold/workflow/rules/nnunet.smk
+++ b/hippunfold/workflow/rules/nnunet.smk
@@ -55,7 +55,9 @@ def get_model_tar(wildcards):
     else:
         model_name = config["modality"]
 
-    local_tar = config["nnunet_model"][model_name]
+    local_tar = config["nnunet_model"].get(model_name, None)
+    if local_tar == None:
+        print(f"ERROR: {model_name} does not exist in nnunet_model in the config file")
 
     dl_path = os.path.abspath(os.path.join(download_dir, local_tar))
     if os.path.exists(dl_path):


### PR DESCRIPTION
Related to issue #229.

Problem was I neglected to add the T1T2w model file/url info, even though the model is available on zenodo along with the others.

The error was occurring in get_model_tar(), but was causing the following cryptic error:

```
CyclicGraphException in line 225 of /home/zeng/Documents/hippunfold/hippunfold/workflow/rules/gifti.smk: Cyclic dependency on rule warp_gii_to_native.
```
since the get_model_tar() function was silently failing since the T1T2w model key didn't exist in the config.

An additional check has now also been added which should give a more meaningful error message if this were to happen in the future.

Note: to use the T1T2w model you will have to run `hippunfold_download_models` again (will download missing models only). I'll also build a new container so it is present there too..