### PR TITLE
ensure use of Laplace coords follows gm mask

### DIFF
--- a/hippunfold/workflow/rules/gifti.smk
+++ b/hippunfold/workflow/rules/gifti.smk
@@ -571,7 +571,7 @@ rule unfolded_registration:
             hemi="{hemi}"
         ),
     container:
-        config["singularity"]["ants"]
+        config["singularity"]["autotop"]
     group:
         "subj"
     log:

--- a/hippunfold/workflow/rules/subfields.smk
+++ b/hippunfold/workflow/rules/subfields.smk
@@ -100,6 +100,9 @@ rule label_subfields_from_vol_coords_corobl:
             **config["subj_wildcards"]
         ),
         nii_io=get_laminar_coords,
+        labelmap = unpack(get_inputs_laplace),
+    params:
+        gm_labels=lambda wildcards: config["laplace_labels"][wildcards.dir]["gm"],
     output:
         nii_label=bids(
             root=work,

--- a/hippunfold/workflow/rules/subfields.smk
+++ b/hippunfold/workflow/rules/subfields.smk
@@ -100,9 +100,9 @@ rule label_subfields_from_vol_coords_corobl:
             **config["subj_wildcards"]
         ),
         nii_io=get_laminar_coords,
-        labelmap = unpack(get_inputs_laplace),
+        labelmap = get_labels_for_laplace,
     params:
-        gm_labels=lambda wildcards: config["laplace_labels"][wildcards.dir]["gm"],
+        gm_labels=lambda wildcards: config["laplace_labels"]["AP"]["gm"],
     output:
         nii_label=bids(
             root=work,

--- a/hippunfold/workflow/rules/warps.smk
+++ b/hippunfold/workflow/rules/warps.smk
@@ -165,8 +165,10 @@ rule create_warps_hipp:
             suffix="refcoords.nii.gz",
             **config["subj_wildcards"]
         ),
+        labelmap = unpack(get_inputs_laplace),
     params:
         interp_method="linear",
+        gm_labels=lambda wildcards: config["laplace_labels"][wildcards.dir]["gm"],
     resources:
         mem_mb=16000,
     output:

--- a/hippunfold/workflow/rules/warps.smk
+++ b/hippunfold/workflow/rules/warps.smk
@@ -165,10 +165,10 @@ rule create_warps_hipp:
             suffix="refcoords.nii.gz",
             **config["subj_wildcards"]
         ),
-        labelmap = unpack(get_inputs_laplace),
+        labelmap = get_labels_for_laplace,
     params:
         interp_method="linear",
-        gm_labels=lambda wildcards: config["laplace_labels"][wildcards.dir]["gm"],
+        gm_labels=lambda wildcards: config["laplace_labels"]["AP"]["gm"],
     resources:
         mem_mb=16000,
     output:

--- a/hippunfold/workflow/rules/warps.smk
+++ b/hippunfold/workflow/rules/warps.smk
@@ -289,8 +289,10 @@ rule create_warps_dentate:
             suffix="refcoords.nii.gz",
             **config["subj_wildcards"]
         ),
+        labelmap = get_labels_for_laplace,
     params:
         interp_method="linear",
+        gm_labels=lambda wildcards: config["laplace_labels"]["PD"]["sink"],
     resources:
         mem_mb=16000,
     output:

--- a/hippunfold/workflow/scripts/create_warps.py
+++ b/hippunfold/workflow/scripts/create_warps.py
@@ -42,9 +42,13 @@ coord_ap = coord_ap_nib.get_fdata()
 coord_pd = coord_pd_nib.get_fdata()
 coord_io = coord_io_nib.get_fdata()
 
-# get mask of coords  (note: this leaves out coord=0)
-mask = (coord_ap > 0) | (coord_pd > 0)  # some points were lost, especially IO
-num_mask_voxels = np.sum(mask > 0)
+# get mask of coords
+lbl_nib = nib.load(snakemake.input.lbl)
+lbl = lbl_nib.get_fdata()
+for i in snakemake.params.gm_labels:
+    idxgm[lbl == i] = 1
+mask = idxgm==1
+num_mask_voxels = np.sum(mask)
 print(f"num_mask_voxels {num_mask_voxels}", file=logfile, flush=True)
 
 # get indices of mask voxels

--- a/hippunfold/workflow/scripts/create_warps.py
+++ b/hippunfold/workflow/scripts/create_warps.py
@@ -43,8 +43,9 @@ coord_pd = coord_pd_nib.get_fdata()
 coord_io = coord_io_nib.get_fdata()
 
 # get mask of coords
-lbl_nib = nib.load(snakemake.input.lbl)
+lbl_nib = nib.load(snakemake.input.labelmap)
 lbl = lbl_nib.get_fdata()
+idxgm = np.zeros(lbl.shape)
 for i in snakemake.params.gm_labels:
     idxgm[lbl == i] = 1
 mask = idxgm==1

--- a/hippunfold/workflow/scripts/label_subfields_from_vol_coords.py
+++ b/hippunfold/workflow/scripts/label_subfields_from_vol_coords.py
@@ -30,8 +30,15 @@ ap_img = ap_nib.get_fdata()
 pd_img = pd_nib.get_fdata()
 io_img = io_nib.get_fdata()
 
-# create mask (TODO: maybe load a separate mask instead, so valid coords=0 are not discarded)
-mask = np.logical_or(ap_img > 0, pd_img > 0, io_img > 0)
+# get mask of coords
+lbl_nib = nib.load(snakemake.input.lbl)
+lbl = lbl_nib.get_fdata()
+idxgm = np.zeros(lbl.shape)
+for i in snakemake.params.gm_labels:
+    idxgm[lbl == i] = 1
+mask = idxgm==1
+num_mask_voxels = np.sum(mask)
+print(f"num_mask_voxels {num_mask_voxels}", file=logfile, flush=True)
 
 
 # interpolate

--- a/hippunfold/workflow/scripts/label_subfields_from_vol_coords.py
+++ b/hippunfold/workflow/scripts/label_subfields_from_vol_coords.py
@@ -31,15 +31,12 @@ pd_img = pd_nib.get_fdata()
 io_img = io_nib.get_fdata()
 
 # get mask of coords
-lbl_nib = nib.load(snakemake.input.lbl)
+lbl_nib = nib.load(snakemake.input.labelmap)
 lbl = lbl_nib.get_fdata()
 idxgm = np.zeros(lbl.shape)
 for i in snakemake.params.gm_labels:
     idxgm[lbl == i] = 1
 mask = idxgm==1
-num_mask_voxels = np.sum(mask)
-print(f"num_mask_voxels {num_mask_voxels}", file=logfile, flush=True)
-
 
 # interpolate
 query_points = np.vstack((ap_img[mask], pd_img[mask], io_img[mask])).T


### PR DESCRIPTION
This has been bothing me for a while, so I finally fixed it

Using Laplace coords (both in generating warps and in subfield labelling) should use a mask that comes from the grey matter mask. Up to now we took a shortcut of defining that mask from the coords themselves, but there could be a few voxels where all 3 coordinates==0. This fixes that.
Also, sometimes Laplace coords extend (ie. >0) beyond the original mask into the endpoints, which get included in the interpolation. This should also avoid that issue.