### PR TITLE
Fix quality action

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@master
 
       - name: Update changelog
         uses: release-drafter/release-drafter@v5

--- a/.github/workflows/dags.yml
+++ b/.github/workflows/dags.yml
@@ -30,7 +30,7 @@ jobs:
           ref: refs/heads/master
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install non-python dependencies

--- a/.github/workflows/manual_release_drafter.yml
+++ b/.github/workflows/manual_release_drafter.yml
@@ -20,7 +20,7 @@ jobs:
           echo "Date: ${{ github.event.inputs.date }}"
           echo "Comments: ${{ github.event.inputs.comments }}"
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@master
 
       - name: Update changelog
         uses: release-drafter/release-drafter@v5

--- a/.github/workflows/push_container.yml
+++ b/.github/workflows/push_container.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@master
       
       - name: Log in to Docker Hub
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9

--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@master
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.8'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-3.8
@@ -42,7 +42,7 @@ jobs:
       #----------------------------------------------
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-3.8
@@ -76,12 +76,12 @@ jobs:
       matrix:
         python-version: ['3.8']
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@master
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.python-version }}
@@ -102,7 +102,7 @@ jobs:
     #----------------------------------------------
     - name: Load cached venv
       id: cached-poetry-dependencies
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: .venv
         key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-${{ matrix.python-version }}

--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -5,6 +5,7 @@ name: Python package
 
 on:
   push:
+  workflow_dispatch:
 #    branches: [ main ]
 #  pull_request:
 #    branches: [ main ]

--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -37,6 +37,10 @@ jobs:
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
+      - name: Disable Poetry modern installation
+        run: |
+          poetry config installer.modern-installation false
+      #----------------------------------------------
       #----------------------------------------------
       #       load cached venv if cache exists
       #----------------------------------------------
@@ -97,6 +101,9 @@ jobs:
       with:
         virtualenvs-create: true
         virtualenvs-in-project: true
+    - name: Disable Poetry modern installation
+      run: |
+        poetry config installer.modern-installation false
     #----------------------------------------------
     #       load cached venv if cache exists
     #----------------------------------------------


### PR DESCRIPTION
@akhanf mentioned that the quality action has been failing when trying to install a package (see [here](https://github.com/khanlab/hippunfold/actions/runs/4546842822)).

Turns out this is due to a change made in the latest version of _Poetry_ (the actions workflow doesn't pin the Poetry version used). As of `v1.4.1`, packages are required to use modern installation (see: https://github.com/python-poetry/poetry/issues/7686). This is potentially problematic when relying on older versions of packages and for packages who are still using non-modern installers. This PR fixes this by adding an additional step to disable the modern-installation requirement in the Poetry config.

Also used this PR as an opportunity to: 
* update the versions of action steps that was still using older versions of node.js
* Add a manual trigger for the python-testing workflow