### PR TITLE
Warps fix

### DIFF
--- a/hippunfold/workflow/scripts/create_warps.py
+++ b/hippunfold/workflow/scripts/create_warps.py
@@ -119,8 +119,8 @@ points = (
 # get unfolded grid (from 0 to 1, not world coords), using meshgrid:
 #  note: indexing='ij' to swap the ordering of x and y
 (unfold_gx, unfold_gy, unfold_gz) = np.meshgrid(
-    np.linspace(0, 1, unfold_dims[0]+2)[1:-1],
-    np.linspace(0, 1, unfold_dims[1]+2)[1:-1],
+    np.linspace(0, 1, unfold_dims[0]),
+    np.linspace(0, 1, unfold_dims[1]),
     np.linspace(0, 1, unfold_dims[2]+2)[1:-1],
     indexing="ij",
 )

--- a/hippunfold/workflow/scripts/create_warps.py
+++ b/hippunfold/workflow/scripts/create_warps.py
@@ -119,9 +119,9 @@ points = (
 # get unfolded grid (from 0 to 1, not world coords), using meshgrid:
 #  note: indexing='ij' to swap the ordering of x and y
 (unfold_gx, unfold_gy, unfold_gz) = np.meshgrid(
-    np.linspace(0, 1, unfold_dims[0]),
-    np.linspace(0, 1, unfold_dims[1]),
-    np.linspace(0, 1, unfold_dims[2]),
+    np.linspace(0, 1, unfold_dims[0]+2)[1:-1],
+    np.linspace(0, 1, unfold_dims[1]+2)[1:-1],
+    np.linspace(0, 1, unfold_dims[2]+2)[1:-1],
     indexing="ij",
 )
 


### PR DESCRIPTION
OK this is a small fix and results in surfaces that are shifted slightly towards the middle, but I think its still very important.

I started getting this issue in some histology unfolding, and couldn't fix it by modifying the segmentations or the laplace coordinates:
![innersurf_displaced](https://github.com/khanlab/hippunfold/assets/25106300/82862673-9e2c-4177-b4e9-71a6bf5e935f)

This displaced surface didn't even line up with any of the x-y-z-axes.

Eventually I realized it went as far back as the inner-most layer of the warp:
![warpfield_displaced](https://github.com/khanlab/hippunfold/assets/25106300/2f6e1ee0-9197-4c2e-a835-312de036430c)

As it turns out, some of this layer was outside of the convex hull spanned by the Laplace coordinates. I played around with the interpolation/extrapolation methods, but no luck. Finally i realized that the extrapolated areas that were working just fine, and the error was occuring because there were a few Laplace coordinates present in the inner-most unfolded layer. These values must have been really similar to the values in the layer above them despite being separated by a whole IO layer, and so the linear interpolation was being thrown way outside. 

This fix should avoid the issue altogether, and has worked in a few similar histology samples now. I think it may have also caused an issue in some previously processed MRI data as well, so I'm very happy to have it solved!