### PR TITLE
curvature was producing a few outlier extreme values

### DIFF
--- a/hippunfold/workflow/rules/gifti.smk
+++ b/hippunfold/workflow/rules/gifti.smk
@@ -946,7 +946,7 @@ rule calculate_curvature_from_surface2:
         ),
     output:
         gii=bids(
-            root=root,
+            root=work,
             datatype="surf",
             den="{density}",
             suffix="curvature.shape.gii",
@@ -979,7 +979,7 @@ rule normalize_curvature2:
         ),
     output:
         gii=bids(
-            root=root,
+            root=work,
             datatype="surf",
             den="{density}",
             suffix="curvature.shape.gii",

--- a/hippunfold/workflow/rules/gifti.smk
+++ b/hippunfold/workflow/rules/gifti.smk
@@ -971,7 +971,7 @@ rule normalize_curvature2:
             datatype="surf",
             den="{density}",
             suffix="curvature.shape.gii",
-            space="corobl",
+            space="{space}",
             hemi="{hemi}",
             desc="unnorm",
             label="hipp",
@@ -983,7 +983,7 @@ rule normalize_curvature2:
             datatype="surf",
             den="{density}",
             suffix="curvature.shape.gii",
-            space="corobl",
+            space="{space}",
             hemi="{hemi}",
             label="hipp",
             **config["subj_wildcards"]

--- a/hippunfold/workflow/rules/gifti.smk
+++ b/hippunfold/workflow/rules/gifti.smk
@@ -979,7 +979,7 @@ rule normalize_curvature2:
         ),
     output:
         gii=bids(
-            root=work,
+            root=root,
             datatype="surf",
             den="{density}",
             suffix="curvature.shape.gii",

--- a/hippunfold/workflow/rules/gifti.smk
+++ b/hippunfold/workflow/rules/gifti.smk
@@ -985,7 +985,7 @@ rule normalize_curvature2:
             suffix="curvature.shape.gii",
             space="{space}",
             hemi="{hemi}",
-            label="hipp",
+            label="{autotop}",
             **config["subj_wildcards"]
         ),
     group:

--- a/hippunfold/workflow/rules/gifti.smk
+++ b/hippunfold/workflow/rules/gifti.smk
@@ -317,43 +317,6 @@ rule calculate_gyrification1:
         " -var nativearea {input.native_surfarea} -var unfoldarea {input.unfold_surfarea} &> {log}"
 
 
-rule smooth_surface1:
-    input:
-        gii=bids(
-            root=work,
-            datatype="surf",
-            den="{density}",
-            suffix="midthickness.surf.gii",
-            space="corobl",
-            unfoldreg="none",
-            hemi="{hemi}",
-            label="hipp",
-            **config["subj_wildcards"]
-        ),
-    params:
-        strength=0.6,
-        iterations=100,
-    output:
-        gii=bids(
-            root=work,
-            datatype="surf",
-            den="{density}",
-            suffix="midthickness.surf.gii",
-            space="corobl",
-            unfoldreg="none",
-            hemi="{hemi}",
-            label="hipp",
-            desc="smoothed",
-            **config["subj_wildcards"]
-        ),
-    container:
-        config["singularity"]["autotop"]
-    group:
-        "subj"
-    shell:
-        "wb_command -surface-smoothing {input.gii} {params.strength} {params.iterations} {output.gii}"
-
-
 rule calculate_curvature_from_surface1:
     input:
         gii=bids(
@@ -365,7 +328,41 @@ rule calculate_curvature_from_surface1:
             unfoldreg="none",
             hemi="{hemi}",
             label="hipp",
-            desc="smoothed",
+            **config["subj_wildcards"]
+        ),
+    output:
+        gii=bids(
+            root=work,
+            datatype="surf",
+            den="{density}",
+            suffix="curvature.shape.gii",
+            space="corobl",
+            unfoldreg="none",
+            hemi="{hemi}",
+            desc="unnorm",
+            label="hipp",
+            **config["subj_wildcards"]
+        ),
+    container:
+        config["singularity"]["autotop"]
+    group:
+        "subj"
+    shell:
+        "wb_command -surface-curvature {input} -mean {output}"
+
+
+rule normalize_curvature1:
+    input:
+        gii=bids(
+            root=work,
+            datatype="surf",
+            den="{density}",
+            suffix="curvature.shape.gii",
+            space="corobl",
+            unfoldreg="none",
+            hemi="{hemi}",
+            desc="unnorm",
+            label="hipp",
             **config["subj_wildcards"]
         ),
     output:
@@ -380,12 +377,10 @@ rule calculate_curvature_from_surface1:
             label="hipp",
             **config["subj_wildcards"]
         ),
-    container:
-        config["singularity"]["autotop"]
     group:
         "subj"
-    shell:
-        "wb_command -surface-curvature {input} -mean {output}"
+    script:
+        "../scripts/normalize_tanh.py"
 
 
 rule calculate_thickness_from_surface1:
@@ -937,41 +932,6 @@ rule calculate_gyrification2:
         " -var nativearea {input.native_surfarea} -var unfoldarea {input.unfold_surfarea} &> {log}"
 
 
-rule smooth_surface2:
-    input:
-        gii=bids(
-            root=root,
-            datatype="surf",
-            den="{density}",
-            suffix="midthickness.surf.gii",
-            space="{space}",
-            hemi="{hemi}",
-            label="{autotop}",
-            **config["subj_wildcards"]
-        ),
-    params:
-        strength=0.6,
-        iterations=100,
-    output:
-        gii=bids(
-            root=root,
-            datatype="surf",
-            den="{density}",
-            suffix="midthickness.surf.gii",
-            space="{space}",
-            hemi="{hemi}",
-            label="{autotop}",
-            desc="smoothed",
-            **config["subj_wildcards"]
-        ),
-    container:
-        config["singularity"]["autotop"]
-    group:
-        "subj"
-    shell:
-        "wb_command -surface-smoothing {input.gii} {params.strength} {params.iterations} {output.gii}"
-
-
 rule calculate_curvature_from_surface2:
     input:
         gii=bids(
@@ -982,7 +942,6 @@ rule calculate_curvature_from_surface2:
             space="{space}",
             hemi="{hemi}",
             label="{autotop}",
-            desc="smoothed",
             **config["subj_wildcards"]
         ),
     output:
@@ -993,6 +952,7 @@ rule calculate_curvature_from_surface2:
             suffix="curvature.shape.gii",
             space="{space}",
             hemi="{hemi}",
+            desc="unnorm",
             label="{autotop}",
             **config["subj_wildcards"]
         ),
@@ -1002,6 +962,36 @@ rule calculate_curvature_from_surface2:
         "subj"
     shell:
         "wb_command -surface-curvature {input} -mean {output}"
+
+
+rule normalize_curvature2:
+    input:
+        gii=bids(
+            root=work,
+            datatype="surf",
+            den="{density}",
+            suffix="curvature.shape.gii",
+            space="corobl",
+            hemi="{hemi}",
+            desc="unnorm",
+            label="hipp",
+            **config["subj_wildcards"]
+        ),
+    output:
+        gii=bids(
+            root=work,
+            datatype="surf",
+            den="{density}",
+            suffix="curvature.shape.gii",
+            space="corobl",
+            hemi="{hemi}",
+            label="hipp",
+            **config["subj_wildcards"]
+        ),
+    group:
+        "subj"
+    script:
+        "../scripts/normalize_tanh.py"
 
 
 rule calculate_thickness_from_surface2:

--- a/hippunfold/workflow/scripts/normalize_tanh.py
+++ b/hippunfold/workflow/scripts/normalize_tanh.py
@@ -1,0 +1,8 @@
+import nibabel as nib
+import numpy as np
+
+gii = nib.load(snakemake.input.gii)
+varr = gii.darrays[0].data
+varr = np.tanh(varr)
+
+nib.save(gii, snakemake.output.gii)


### PR DESCRIPTION
It looks like this was mainly caused by smoothing  before calculating curvature https://github.com/khanlab/hippunfold/blob/ef99cc250a975ee3132966af61ed619673be3238/hippunfold/workflow/rules/gifti.smk#L349 Apparently wb_command doesn't handle smoothing of an open-faced surface well:

![image](https://github.com/khanlab/hippunfold/assets/25106300/e2883a99-2877-457e-9f82-9dffc0ff23fd)

This was not an issue for my unsmoothed surfaces.
I'm removing the smoothing, but because there still could be extreme values (eg. from  aced vertex), i'm also normalizing with a tanh function.