### PR TITLE
added neonate_v2 model, minor workflow update for it

### DIFF
--- a/hippunfold/config/nnunet_model_urls.yml
+++ b/hippunfold/config/nnunet_model_urls.yml
@@ -1,6 +1,7 @@
 T1w: 'https://zenodo.org/record/4508747/files/trained_model.3d_fullres.Task101_hcp1200_T1w.nnUNetTrainerV2.model_best.tar'
 T2w: 'https://zenodo.org/record/4508747/files/trained_model.3d_fullres.Task102_hcp1200_T2w.nnUNetTrainerV2.model_best.tar'
 neonateT1w: 'https://zenodo.org/record/5733556/files/trained_model.3d_fullres.Task205_hcp1200_b1000_finetuneround2_dhcp_T1w.nnUNetTrainerV2.model_best.tar'
+neonateT1w_v2: 'https://zenodo.org/record/8209029/files/trained_model.3d_fullres.Task301_dhcp_T1w_synthseg_manuallycorrected.nnUNetTrainer.model_best.tar'
 hippb500: 'https://zenodo.org/record/5732291/files/trained_model.3d_fullres.Task110_hcp1200_b1000crop.nnUNetTrainerV2.model_best.tar'
 T1T2w: 'https://zenodo.org/record/4508747/files/trained_model.3d_fullres.Task103_hcp1200_T1T2w.nnUNetTrainerV2.model_best.tar'
 synthseg_v0.1: 'https://dropbox.com/s/asoanq94ofersv3/trained_model.3d_fullres.Task102_synsegGenDetailed.nnUNetTrainerV2.model_best.tar'

--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -297,6 +297,7 @@ parse_args:
       - neonateT1w
       - synthseg_v0.1
       - synthseg_v0.2
+      - neonateT1w_v2
 
 autotop_labels:
   - 'hipp'
@@ -421,6 +422,7 @@ nnunet_model:
   T1T2w: trained_model.3d_fullres.Task103_hcp1200_T1T2w.nnUNetTrainerV2.model_best.tar
   synthseg_v0.1: trained_model.3d_fullres.Task102_synsegGenDetailed.nnUNetTrainerV2.model_best.tar
   synthseg_v0.2: trained_model.3d_fullres.Task203_synthseg.nnUNetTrainerV2.model_best.tar
+  neonateT1w_v2: trained_model.3d_fullres.Task301_dhcp_T1w_synthseg_manuallycorrected.nnUNetTrainer.model_best.tar
 
 crop_native_box: '256x256x256vox'
 crop_native_res: '0.2x0.2x0.2mm'

--- a/hippunfold/workflow/rules/nnunet.smk
+++ b/hippunfold/workflow/rules/nnunet.smk
@@ -47,6 +47,7 @@ def parse_chkpnt_from_tar(wildcards, input):
         raise ValueError("cannot parse chkpnt from model tar")
     return chkpnt
 
+
 def parse_trainer_from_tar(wildcards, input):
     match = re.search("^.*\.(\w+)\..*.tar", input.model_tar)
     if match:


### PR DESCRIPTION
- trained on manually-corrected synthseg segmentations
- inadvertendly picked a non-default "trainer" for nnUNet, so had to also made a minor update to the workflow to support choice of trainer (which was easy since trainer was in the tar name).
- note: this was a mixup when migrating back and forth from nnunet-v2, and I ultimately didn't end up using nnunet-v2 because it would have made it difficult to support both nnunet and nnunet-v2 models (not backwards compatible).