### PR TITLE
replace use of HTTP.remote() with wget

### DIFF
--- a/hippunfold/workflow/rules/nnunet.smk
+++ b/hippunfold/workflow/rules/nnunet.smk
@@ -1,8 +1,5 @@
 import re
 from appdirs import AppDirs
-from snakemake.remote.HTTP import RemoteProvider as HTTPRemoteProvider
-
-HTTP = HTTPRemoteProvider()
 
 
 def get_nnunet_input(wildcards):
@@ -93,14 +90,14 @@ def parse_trainer_from_tar(wildcards, input):
 
 
 rule download_model:
-    input:
-        HTTP.remote(config["nnunet_model"][config["force_nnunet_model"]])
+    params:
+        url=config["nnunet_model"][config["force_nnunet_model"]]
         if config["force_nnunet_model"]
-        else HTTP.remote(config["nnunet_model"][config["modality"]]),
+        else config["nnunet_model"][config["modality"]],
     output:
         model_tar=get_model_tar(),
     shell:
-        "cp {input} {output}"
+        "wget https://{params.url} -O {output}"
 
 
 rule run_inference:


### PR DESCRIPTION
- HTTP.remote() always required an internet connection, even if the downloaded file already existed (it checks modification time on the remote file).
- replaced this with a simple wget in the same download rule, and now we get a free progress bar too..