### PR TITLE
Fix session bug

### DIFF
--- a/hippunfold/workflow/rules/common.smk
+++ b/hippunfold/workflow/rules/common.smk
@@ -333,12 +333,18 @@ def get_final_output():
     modality_suffix = get_modality_suffix(config["modality"])
     modality_key = get_modality_key(config["modality"])
 
+    #use a zip list for subject/session:
+    zip_list = config['input_zip_lists'][modality_key]
+    if 'session' in zip_list:
+        zip_list = snakebids.filter_list(zip_list,{'session':config['sessions']})
+
     final_output.extend(
         expand(
+        expand(
             subj_output,
+            zip,allow_missing=True,
+            **zip_list),
             modality_suffix=modality_suffix,
-            subject=config["input_lists"][modality_key]["subject"],
-            session=config["sessions"],
         )
     )
 

--- a/hippunfold/workflow/rules/common.smk
+++ b/hippunfold/workflow/rules/common.smk
@@ -333,17 +333,14 @@ def get_final_output():
     modality_suffix = get_modality_suffix(config["modality"])
     modality_key = get_modality_key(config["modality"])
 
-    #use a zip list for subject/session:
-    zip_list = config['input_zip_lists'][modality_key]
-    if 'session' in zip_list:
-        zip_list = snakebids.filter_list(zip_list,{'session':config['sessions']})
+    # use a zip list for subject/session:
+    zip_list = config["input_zip_lists"][modality_key]
+    if "session" in zip_list:
+        zip_list = snakebids.filter_list(zip_list, {"session": config["sessions"]})
 
     final_output.extend(
         expand(
-        expand(
-            subj_output,
-            zip,allow_missing=True,
-            **zip_list),
+            expand(subj_output, zip, allow_missing=True, **zip_list),
             modality_suffix=modality_suffix,
         )
     )


### PR DESCRIPTION
This fixes an issue when bids datasets have multiple sessions and not all subjects have the same session.
Using zip_lists solves that, but it turns out zip lists were not actually being used in the target rule, since the last refactoring of the target rules #63 
This ensures zip_lists are used and filters with this expands twice in the `get_final_output()` function to ensure zip lists
are used, filtering the session with the filter_list() function.

Note: should revamp sometime soon to use new snakebids API..