### PR TITLE
Add testing for other python versions

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,13 +1,16 @@
+---
 name: Bump version
 on:
   push:
     branches:
       - master
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - name: Checkout main branch
+        uses: actions/checkout@v4
 
       - name: Update changelog
         uses: release-drafter/release-drafter@v5
@@ -15,6 +18,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Can replace the below with (until pipeline description) with
+      # khanlab/actions/.github/workflows/workflow-version_task-semverGithub.yml
+      # after adding PAT token
       - name: Get previous release version
         run: |
           echo "PREV_VER=$(cat pyproject.toml | grep -o -E '(version\s=\s)([[:punct:]])([0-9]+\.[0-9]+\.[0-9]+.+)([[:punct:]])' | cut -d ' ' -f 3 | tr -d '"')" >> $GITHUB_ENV
@@ -35,22 +41,22 @@ jobs:
         run: |
           echo "NEW_BUMP=$(($BUMP_VER + 1))" >> $GITHUB_ENV
 
-      - name: Update version in pyproject
-        uses: jacobtomlinson/gha-find-replace@master
+      - name: Update version in pyproject.toml
+        uses: jacobtomlinson/gha-find-replace@v3
         with:
           include: "pyproject.toml"
           find: 'version = "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"'
           replace: 'version = "${{ steps.release-drafter.outputs.name }}-pre.${{ env.NEW_BUMP }}"'
 
       - name: Update version in pipeline_description (not actually used)
-        uses: jacobtomlinson/gha-find-replace@master
+        uses: jacobtomlinson/gha-find-replace@v3
         with:
           include: "hippunfold/pipeline_description.json"
           find: '"Version": "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"'
           replace: '"Version": "${{ steps.release-drafter.outputs.name }}-pre.${{ env.NEW_BUMP }}"'
 
       - name: Update version in config/snakebids.yml
-        uses: jacobtomlinson/gha-find-replace@master
+        uses: jacobtomlinson/gha-find-replace@v3
         with:
           include: "hippunfold/config/snakebids.yml"
           find: 'version: "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"'
@@ -65,7 +71,7 @@ jobs:
           git diff-index --quiet HEAD || git commit -m "Bump version to $SNAKEBIDS_VERSION" -a
 
       - name: Push changes
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@v0.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tags: false

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -38,25 +38,24 @@ jobs:
       - name: Update version in pyproject
         uses: jacobtomlinson/gha-find-replace@master
         with:
-          include: 'pyproject.toml'
+          include: "pyproject.toml"
           find: 'version = "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"'
           replace: 'version = "${{ steps.release-drafter.outputs.name }}-pre.${{ env.NEW_BUMP }}"'
 
       - name: Update version in pipeline_description (not actually used)
         uses: jacobtomlinson/gha-find-replace@master
         with:
-          include: 'hippunfold/pipeline_description.json'
+          include: "hippunfold/pipeline_description.json"
           find: '"Version": "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"'
           replace: '"Version": "${{ steps.release-drafter.outputs.name }}-pre.${{ env.NEW_BUMP }}"'
 
       - name: Update version in config/snakebids.yml
         uses: jacobtomlinson/gha-find-replace@master
         with:
-          include: 'hippunfold/config/snakebids.yml'
+          include: "hippunfold/config/snakebids.yml"
           find: 'version: "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"'
           replace: 'version: "${{ steps.release-drafter.outputs.name }}-pre.${{ env.NEW_BUMP }}"'
 
- 
       - name: Commit updates
         env:
           SNAKEBIDS_VERSION: ${{ steps.release-drafter.outputs.name }}-pre.${{ env.NEW_BUMP }}
@@ -70,6 +69,3 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           tags: false
-
-
-

--- a/.github/workflows/dags.yml
+++ b/.github/workflows/dags.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+
       - name: Install non-python dependencies
         run: |
           sudo apt-get install -y graphviz-dev graphviz
@@ -41,10 +42,11 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install snakebids
 
-      - name: Set-up env for hippunfold 
+      - name: Set-up env for hippunfold
         run: |
           echo "HIPPUNFOLD_CACHE_DIR=`pwd`/test_data/fake_models" >> $GITHUB_ENV
           echo "HIPPUNFOLD=./hippunfold/run.py" >> $GITHUB_ENV
+
       - name: Generate rulegraph single T2w bids
         run: |
           $HIPPUNFOLD test_data/bids_singleT2w test_out participant -np --modality T2w --rulegraph | dot -Tsvg > docs/images/rulegraph_T2w.svg
@@ -55,12 +57,9 @@ jobs:
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git diff-index --quiet HEAD || git add docs/images || commit -m "Add updated dags [skip ci]" 
+          git diff-index --quiet HEAD || git add docs/images || commit -m "Add updated dags [skip ci]"
 
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-
-
-

--- a/.github/workflows/dags.yml
+++ b/.github/workflows/dags.yml
@@ -1,31 +1,26 @@
+---
 name: Generate DAG visualizations
-
 on:
   workflow_dispatch:
     inputs:
-      author:
-        description: "Author"
-        required: true
-        default: "github-actions[bot] (user publishing release)"
-      date:
-        description: "Date"
-        required: true
-        default: "YYYY-MM-DD"
       comments:
         description: "Comments"
 
 jobs:
   generate_dag:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9"]
 
     steps:
       - name: Print author
         run: |
-          echo "Author: ${{ github.event.inputs.author }}"
-          echo "Date: ${{ github.event.inputs.date }}"
+          echo "Author: ${{ github.triggering_actor }}"
           echo "Comments: ${{ github.event.inputs.comments }}"
 
-      - uses: actions/checkout@master
+      - name: Checkout main branch
+        uses: actions/checkout@v3
         with:
           ref: refs/heads/master
 
@@ -37,6 +32,7 @@ jobs:
       - name: Install non-python dependencies
         run: |
           sudo apt-get install -y graphviz-dev graphviz
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -52,14 +48,12 @@ jobs:
           $HIPPUNFOLD test_data/bids_singleT2w test_out participant -np --modality T2w --rulegraph | dot -Tsvg > docs/images/rulegraph_T2w.svg
 
       - name: Commit updates
-        env:
-          LATEST_VERSION: ${{ steps.release-drafter.outputs.name }}
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git diff-index --quiet HEAD || git add docs/images || commit -m "Add updated dags [skip ci]"
 
       - name: Push changes
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@v0.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,16 +1,8 @@
+---
 name: Deploy workflow
-
 on:
   workflow_dispatch:
     inputs:
-      author:
-        description: "Author"
-        required: true
-        default: "github-actions[bot] (user publishing release)"
-      date:
-        description: "Date"
-        required: true
-        default: "YYYY-MM-DD"
       comments:
         description: "Comments"
       branch:
@@ -25,11 +17,10 @@ jobs:
     steps:
       - name: Print author
         run: |
-          echo "Author: ${{ github.event.inputs.author }}"
-          echo "Date: ${{ github.event.inputs.date }}"
+          echo "Author: ${{ github.triggering_actor }}"
           echo "Comments: ${{ github.event.inputs.comments }}"
 
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.inputs.branch }}
 
@@ -37,10 +28,13 @@ jobs:
         uses: release-drafter/release-drafter@v5
         id: release-drafter
         with:
-          commitish: ${{ github.event.inputs.branch }}        
+          commitish: ${{ github.event.inputs.branch }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Can replace the below with (until pipeline description) with
+      # khanlab/actions/.github/workflows/workflow-version_task-publishGithub.yml
+      # after adding PAT token
       - name: Set new release version
         env:
           RD_RELEASE: ${{ steps.release-drafter.outputs.name }}
@@ -52,27 +46,26 @@ jobs:
           fi
 
       - name: Update version in pyproject.toml
-        uses: jacobtomlinson/gha-find-replace@master
+        uses: jacobtomlinson/gha-find-replace@v3
         with:
-          include: 'pyproject.toml'
+          include: "pyproject.toml"
           find: 'version = "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"'
           replace: 'version = "${{ env.NEW_RELEASE }}"'
 
       - name: Update version in pipeline_description (not actually used)
-        uses: jacobtomlinson/gha-find-replace@master
+        uses: jacobtomlinson/gha-find-replace@v3
         with:
-          include: 'hippunfold/pipeline_description.json'
+          include: "hippunfold/pipeline_description.json"
           find: '"Version": "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"'
           replace: '"Version": "${{ env.NEW_RELEASE }}"'
 
       - name: Update version in config/snakebids.yml
-        uses: jacobtomlinson/gha-find-replace@master
+        uses: jacobtomlinson/gha-find-replace@v3
         with:
-          include: 'hippunfold/config/snakebids.yml'
+          include: "hippunfold/config/snakebids.yml"
           find: 'version: "(?:([0-9]+\.[0-9]+\.[0-9]+.+)|([0-9]+\.[0-9]+\.[0-9]+))"'
           replace: 'version: "${{ env.NEW_RELEASE }}"'
 
- 
       - name: Commit updates
         env:
           LATEST_VERSION: ${{ env.NEW_RELEASE }}
@@ -82,7 +75,7 @@ jobs:
           git diff-index --quiet HEAD || git commit -m "Bump version to $LATEST_VERSION" -a
 
       - name: Push changes
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@v0.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -92,5 +85,3 @@ jobs:
           publish: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-

--- a/.github/workflows/manual_release_drafter.yml
+++ b/.github/workflows/manual_release_drafter.yml
@@ -1,12 +1,8 @@
+---
 name: Manual release-drafter update
-
 on:
   workflow_dispatch:
     inputs:
-      author:
-        description: "Author"
-        required: true
-        default: "github-actions[bot] (user publishing release)"
       comments:
         description: "Update release drafter notes"
 
@@ -16,11 +12,11 @@ jobs:
     steps:
       - name: Print workflow information
         run: |
-          echo "Author: ${{ github.event.inputs.author }}"
-          echo "Date: ${{ github.event.inputs.date }}"
+          echo "Author: ${{ github.triggering_actor }}"
           echo "Comments: ${{ github.event.inputs.comments }}"
 
-      - uses: actions/checkout@master
+      - name: Checkout main branch
+        uses: actions/checkout@v4
 
       - name: Update changelog
         uses: release-drafter/release-drafter@v5

--- a/.github/workflows/push_container.yml
+++ b/.github/workflows/push_container.yml
@@ -1,53 +1,18 @@
+---
 # This workflow uses actions that are not certified by GitHub.
 # They are provided by a third-party and are governed by
 # separate terms of service, privacy policy, and support
 # documentation.
 
 name: Publish Docker image
-
-on: 
+on:
   workflow_dispatch:
   release:
     types: [published]
 
 jobs:
   push_to_registries:
-    name: Push Docker image to multiple registries
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
-    steps:
-      - name: Check out the repo
-        uses: actions/checkout@master
-      
-      - name: Log in to Docker Hub
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      
-      - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: |
-            ${{ github.repository }}
-            ghcr.io/${{ github.repository }}
-          flavor: |
-            latest=auto
-      
-      - name: Build and push Docker images
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+    uses: khanlab/actions/.github/workflows/workflow-release_task-deployDocker.yml@v0.3.2
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -11,21 +11,23 @@ on:
 #    branches: [ main ]
 
 jobs:
-  
   quality:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repo
         uses: actions/checkout@master
+
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: "3.8"
+
       - uses: actions/cache@v3
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-3.8
           restore-keys: ${{ runner.os }}-pip-3.8
+
       - name: Install non-python dependencies
         run: |
           sudo apt-get install -y graphviz-dev
@@ -37,6 +39,7 @@ jobs:
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
+
       - name: Disable Poetry modern installation
         run: |
           poetry config installer.modern-installation false
@@ -71,124 +74,141 @@ jobs:
         run: poetry run black hippunfold --check
       - name: snakefmt
         run: poetry run snakefmt hippunfold --check
- 
-  test:
 
+  test:
     runs-on: ubuntu-latest
-    needs: [ 'quality'  ]
+    needs: ["quality"]
     strategy:
       matrix:
-        python-version: ['3.8']
+        python-version: ["3.8"]
+
     steps:
-    - uses: actions/checkout@master
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
-      with:
-        python-version: ${{ matrix.python-version }}
-    - uses: actions/cache@v3
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ matrix.python-version }}
-        restore-keys: ${{ runner.os }}-pip-${{ matrix.python-version }}
-    - name: Install non-python dependencies
-      run: |
-        sudo apt-get install -y graphviz-dev
-    #----------------------------------------------
-    #  -----  install & configure poetry  -----
-    #----------------------------------------------
-    - name: Install Poetry
-      uses: snok/install-poetry@v1
-      with:
-        virtualenvs-create: true
-        virtualenvs-in-project: true
-    - name: Disable Poetry modern installation
-      run: |
-        poetry config installer.modern-installation false
-    #----------------------------------------------
-    #       load cached venv if cache exists
-    #----------------------------------------------
-    - name: Load cached venv
-      id: cached-poetry-dependencies
-      uses: actions/cache@v3
-      with:
-        path: .venv
-        key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-${{ matrix.python-version }}
-    #----------------------------------------------
-    # install dependencies if cache does not exist
-    #----------------------------------------------
-    - name: Install dependencies
-      if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-      run: poetry install --no-interaction --no-root
-    #----------------------------------------------
-    # install your root project, if required
-    #----------------------------------------------
-    - name: Install library
-      run: poetry install --no-interaction
-    - name: Set-up env for hippunfold 
-      run: |
-        echo "HIPPUNFOLD_CACHE_DIR=`pwd`/test_data/fake_models" >> $GITHUB_ENV
-    - name: Test single T2w bids
-      run: |
-        poetry run hippunfold test_data/bids_singleT2w test_out participant -np --modality T2w
-    - name: Test running on existing folder
-      run: |
-        mkdir test_newout
-        poetry run hippunfold test_data/bids_singleT2w test_newout participant -np --modality T2w
-    - name: Test single T2w bids, right hemi
-      run: |
-        poetry run hippunfold test_data/bids_singleT2w test_out participant -np --modality T2w --hemi R
-    - name: Test single T2w bids, left hemi
-      run: |
-        poetry run hippunfold test_data/bids_singleT2w test_out participant -np --modality T2w --hemi L
-    - name: Test multiple T2w bids
-      run: |
-        poetry run hippunfold test_data/bids_multiT2w test_out participant -np --modality T2w
-    - name: Test T1w bids
-      run: |
-        poetry run hippunfold test_data/bids_T1w test_out participant -np --modality T1w
-    - name: Test hipp b500 bids
-      run: |
-        poetry run hippunfold test_data/bids_hippb500 test_out participant -np --modality hippb500
-    - name: Test T1w multi-session/longitudinal bids
-      run: |
-        poetry run hippunfold test_data/bids_T1w_longitudinal test_out participant -np --modality T1w
-    - name: Test single T2w multi-session/longitudinal bids
-      run: |
-        poetry run hippunfold test_data/bids_singleT2w_longitudinal test_out participant -np --modality T2w
-    - name: Test manual seg T2w bids
-      run: |
-        poetry run hippunfold test_data/bids_segT2w test_out participant -np --modality segT2w
-    - name: Test cropseg bids, with path override
-      run: |
-        poetry run hippunfold . test_out participant -np --modality cropseg --path_cropseg test_data/data_cropseg/sub-{subject}_hemi-{hemi}_dseg.nii.gz
-    - name: Test cropseg bids, with path override, left hemi
-      run: | 
-        poetry run hippunfold . test_out participant -np --modality cropseg --path_cropseg test_data/data_cropseg_1hemi/sub-{subject}_hemi-{hemi}_dseg.nii.gz --hemi L
-    - name: Test T2w with T1w template registration
-      run: |
-        poetry run hippunfold test_data/bids_singleT2w test_out participant -np --modality T2w --t1_reg_template
-    - name: Test T2w with T1w output space 
-      run: |
-        poetry run hippunfold test_data/bids_singleT2w test_out participant -np --modality T2w --output_space T1w
-    - name: Test modality T2w with myelin map
-      run: |
-        poetry run hippunfold test_data/bids_singleT2w test_out participant -np --modality T2w --generate-myelin-map
-    - name: Test modality T1w with myelin map
-      run: |
-        poetry run hippunfold test_data/bids_singleT2w test_out participant -np --modality T1w --generate-myelin-map
-    - name: Test modality T1w with magdeburg atlas
-      run: |
-        poetry run hippunfold test_data/bids_T1w test_out participant -np --modality T1w --atlas magdeburg
-    - name: Test modality T1w with freesurfer atlas
-      run: |
-        poetry run hippunfold test_data/bids_T1w test_out participant -np --modality T1w --atlas freesurfer
-    - name: Test modality T1w with bigbrain and freesurfer atlas
-      run: |
-        poetry run hippunfold test_data/bids_T1w test_out participant -np --modality T1w --atlas bigbrain freesurfer
+      - uses: actions/checkout@master
 
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
 
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}
+          restore-keys: ${{ runner.os }}-pip-${{ matrix.python-version }}
 
+      - name: Install non-python dependencies
+        run: |
+          sudo apt-get install -y graphviz-dev
+      #----------------------------------------------
+      #  -----  install & configure poetry  -----
+      #----------------------------------------------
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
 
+      - name: Disable Poetry modern installation
+        run: |
+          poetry config installer.modern-installation false
+      #----------------------------------------------
+      #       load cached venv if cache exists
+      #----------------------------------------------
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v3
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-${{ matrix.python-version }}
+      #----------------------------------------------
+      # install dependencies if cache does not exist
+      #----------------------------------------------
+      - name: Install dependencies
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        run: poetry install --no-interaction --no-root
+      #----------------------------------------------
+      # install your root project, if required
+      #----------------------------------------------
+      - name: Install library
+        run: poetry install --no-interaction
 
+      - name: Set-up env for hippunfold
+        run: |
+          echo "HIPPUNFOLD_CACHE_DIR=`pwd`/test_data/fake_models" >> $GITHUB_ENV
 
+      - name: Test single T2w bids
+        run: |
+          poetry run hippunfold test_data/bids_singleT2w test_out participant -np --modality T2w
 
+      - name: Test running on existing folder
+        run: |
+          mkdir test_newout
+          poetry run hippunfold test_data/bids_singleT2w test_newout participant -np --modality T2w
+
+      - name: Test single T2w bids, right hemi
+        run: |
+          poetry run hippunfold test_data/bids_singleT2w test_out participant -np --modality T2w --hemi R
+
+      - name: Test single T2w bids, left hemi
+        run: |
+          poetry run hippunfold test_data/bids_singleT2w test_out participant -np --modality T2w --hemi L
+
+      - name: Test multiple T2w bids
+        run: |
+          poetry run hippunfold test_data/bids_multiT2w test_out participant -np --modality T2w
+
+      - name: Test T1w bids
+        run: |
+          poetry run hippunfold test_data/bids_T1w test_out participant -np --modality T1w
+
+      - name: Test hipp b500 bids
+        run: |
+          poetry run hippunfold test_data/bids_hippb500 test_out participant -np --modality hippb500
+
+      - name: Test T1w multi-session/longitudinal bids
+        run: |
+          poetry run hippunfold test_data/bids_T1w_longitudinal test_out participant -np --modality T1w
+
+      - name: Test single T2w multi-session/longitudinal bids
+        run: |
+          poetry run hippunfold test_data/bids_singleT2w_longitudinal test_out participant -np --modality T2w
+
+      - name: Test manual seg T2w bids
+        run: |
+          poetry run hippunfold test_data/bids_segT2w test_out participant -np --modality segT2w
+
+      - name: Test cropseg bids, with path override
+        run: |
+          poetry run hippunfold . test_out participant -np --modality cropseg --path_cropseg test_data/data_cropseg/sub-{subject}_hemi-{hemi}_dseg.nii.gz
+
+      - name: Test cropseg bids, with path override, left hemi
+        run: |
+          poetry run hippunfold . test_out participant -np --modality cropseg --path_cropseg test_data/data_cropseg_1hemi/sub-{subject}_hemi-{hemi}_dseg.nii.gz --hemi L
+
+      - name: Test T2w with T1w template registration
+        run: |
+          poetry run hippunfold test_data/bids_singleT2w test_out participant -np --modality T2w --t1_reg_template
+
+      - name: Test T2w with T1w output space
+        run: |
+          poetry run hippunfold test_data/bids_singleT2w test_out participant -np --modality T2w --output_space T1w
+
+      - name: Test modality T2w with myelin map
+        run: |
+          poetry run hippunfold test_data/bids_singleT2w test_out participant -np --modality T2w --generate-myelin-map
+
+      - name: Test modality T1w with myelin map
+        run: |
+          poetry run hippunfold test_data/bids_singleT2w test_out participant -np --modality T1w --generate-myelin-map
+
+      - name: Test modality T1w with magdeburg atlas
+        run: |
+          poetry run hippunfold test_data/bids_T1w test_out participant -np --modality T1w --atlas magdeburg
+
+      - name: Test modality T1w with freesurfer atlas
+        run: |
+          poetry run hippunfold test_data/bids_T1w test_out participant -np --modality T1w --atlas freesurfer
+
+      - name: Test modality T1w with bigbrain and freesurfer atlas
+        run: |
+          poetry run hippunfold test_data/bids_T1w test_out participant -np --modality T1w --atlas bigbrain freesurfer

--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -1,77 +1,32 @@
+---
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python package
-
+name: Lint and test workflow
 on:
   push:
   workflow_dispatch:
-#    branches: [ main ]
-#  pull_request:
-#    branches: [ main ]
 
 jobs:
   quality:
     runs-on: ubuntu-latest
+
     steps:
-      - name: Clone repo
-        uses: actions/checkout@master
-
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.8"
-
-      - uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-3.8
-          restore-keys: ${{ runner.os }}-pip-3.8
-
       - name: Install non-python dependencies
         run: |
           sudo apt-get install -y graphviz-dev
-      #----------------------------------------------
-      #  -----  install & configure poetry  -----
-      #----------------------------------------------
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          virtualenvs-create: true
-          virtualenvs-in-project: true
 
-      - name: Disable Poetry modern installation
-        run: |
-          poetry config installer.modern-installation false
-      #----------------------------------------------
-      #----------------------------------------------
-      #       load cached venv if cache exists
-      #----------------------------------------------
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v3
+      - name: Setup Python environment
+        uses: khanlab/actions/.github/actions/action-setup_task-installPyProject@v0.3.2
         with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-3.8
-      #----------------------------------------------
-      # install dependencies if cache does not exist
-      #----------------------------------------------
-      - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
-      #----------------------------------------------
-      # install your root project, if required
-      #----------------------------------------------
-      - name: Install library
-        run: poetry install --no-interaction
+          python-version: "3.9"
 
-      #----------------------------------------------
-      #       run python style checks
-      #----------------------------------------------
       - name: isort
         run: poetry run isort hippunfold/*.py -c
+
       - name: Black
         run: poetry run black hippunfold --check
+
       - name: snakefmt
         run: poetry run snakefmt hippunfold --check
 
@@ -80,59 +35,25 @@ jobs:
     needs: ["quality"]
     strategy:
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.7", "3.8", "3.9"]
 
     steps:
-      - uses: actions/checkout@master
+      - name: Install non-python dependencies
+        run: |
+          sudo apt-get install -y graphviz-dev
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: actions/cache@v3
+      - name: Setup Python environments
+        uses: khanlab/actions/.github/actions/action-setup_task-installPyProject@v0.3.2
         with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}
-          restore-keys: ${{ runner.os }}-pip-${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}
+          install-library: true
 
-      - name: Install non-python dependencies
-        run: |
-          sudo apt-get install -y graphviz-dev
-      #----------------------------------------------
-      #  -----  install & configure poetry  -----
-      #----------------------------------------------
-      - name: Install Poetry
-        uses: snok/install-poetry@v1
-        with:
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-
-      - name: Disable Poetry modern installation
-        run: |
-          poetry config installer.modern-installation false
-      #----------------------------------------------
-      #       load cached venv if cache exists
-      #----------------------------------------------
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v3
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}-${{ matrix.python-version }}
-      #----------------------------------------------
-      # install dependencies if cache does not exist
-      #----------------------------------------------
-      - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
-        run: poetry install --no-interaction --no-root
-      #----------------------------------------------
-      # install your root project, if required
-      #----------------------------------------------
-      - name: Install library
-        run: poetry install --no-interaction
-
-      - name: Set-up env for hippunfold
+      - name: Setup env for hippunfold
         run: |
           echo "HIPPUNFOLD_CACHE_DIR=`pwd`/test_data/fake_models" >> $GITHUB_ENV
 


### PR DESCRIPTION
The current testing workflow only supports Python 3.8 - this adds additional hippunfold-supported Python versions (3.7 and 3.9) for testing. Given it's a dry-run test, it may not catch any run-time issues, but would potentially catch dependency issues at the installation step.

Additionally, a few minor maintenance things:
* Versioned action steps instead of the using the `main` branch (which may be a dev branch)
* Where possible, switched to reusable workflows for easier maintenance and reduce the number of lines in the file.