### PR TITLE
use naturalneighbour interpolation instead of linear barycentric

### DIFF
--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -159,6 +159,7 @@ parse_args:
   --inject_template:
     choices:
       - 'upenn'
+      - 'dHCP'
       - 'MBMv2'
       - 'MBMv3'
       - 'CIVM'
@@ -327,10 +328,14 @@ parse_args:
       - synthseg_v0.2
       - neonateT1w_v2
 
+
+
+
+# --- surface specific configuration -- 
+
 autotop_labels:
   - 'hipp'
   - 'dentate'
-
 
 surf_types:
   hipp:

--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -608,10 +608,6 @@ unfold_vol_ref:
       - '2.5'
     orient: RPI
 
-unfold_crop_epsilon_fractions:
-    - 0
-    - 0
-    - 0.0625 #1/16
 
 # space for uniform unfolded grid:
 #  currently only used for interpolating hipp subfields on surface

--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -370,7 +370,7 @@ cifti_metric_types:
 #--- workflow specific configuration -- 
 
 singularity:
-  autotop: 'docker://khanlab/hippunfold_deps:v0.5.0'
+  autotop: 'docker://khanlab/hippunfold_deps:v0.5.1'
 
 xfm_identity: resources/etc/identity_xfm.txt
 xfm_identity_itk: resources/etc/identity_xfm_itk.txt

--- a/hippunfold/workflow/rules/common.smk
+++ b/hippunfold/workflow/rules/common.smk
@@ -24,23 +24,40 @@ def get_modality_suffix(modality):
 
 
 def get_final_spec():
-    specs = expand(
-        bids(
-            root=root,
-            datatype="surf",
-            den="{density}",
-            space="{space}",
-            hemi="{hemi}",
-            label="{autotop}",
-            suffix="surfaces.spec",
-            **config["subj_wildcards"],
-        ),
-        density=config["output_density"],
-        space=ref_spaces,
-        hemi=config["hemi"],
-        autotop=config["autotop_labels"],
-        allow_missing=True,
-    )
+    if len(config["hemi"]) == 2:
+        specs = expand(
+            bids(
+                root=root,
+                datatype="surf",
+                den="{density}",
+                space="{space}",
+                label="{autotop}",
+                suffix="surfaces.spec",
+                **config["subj_wildcards"],
+            ),
+            density=config["output_density"],
+            space=ref_spaces,
+            autotop=config["autotop_labels"],
+            allow_missing=True,
+        )
+    else:
+        specs = expand(
+            bids(
+                root=root,
+                datatype="surf",
+                den="{density}",
+                space="{space}",
+                hemi="{hemi}",
+                label="{autotop}",
+                suffix="surfaces.spec",
+                **config["subj_wildcards"],
+            ),
+            density=config["output_density"],
+            space=ref_spaces,
+            hemi=config["hemi"],
+            autotop=config["autotop_labels"],
+            allow_missing=True,
+        )
     return specs
 
 

--- a/hippunfold/workflow/rules/common.smk
+++ b/hippunfold/workflow/rules/common.smk
@@ -24,41 +24,69 @@ def get_modality_suffix(modality):
 
 
 def get_final_spec():
-    if len(config["hemi"]) == 2:
-        specs = expand(
+    specs = expand(
+        bids(
+            root=root,
+            datatype="surf",
+            den="{density}",
+            space="{space}",
+            hemi="{hemi}",
+            label="{autotop}",
+            suffix="surfaces.spec",
+            **config["subj_wildcards"],
+        ),
+        density=config["output_density"],
+        space=ref_spaces,
+        hemi=config["hemi"],
+        autotop=config["autotop_labels"],
+        allow_missing=True,
+    )
+    return specs
+
+
+def get_final_surf():
+    gii = []
+    gii.extend(
+        expand(
             bids(
                 root=root,
                 datatype="surf",
                 den="{density}",
-                space="{space}",
-                label="{autotop}",
-                suffix="surfaces.spec",
-                **config["subj_wildcards"],
-            ),
-            density=config["output_density"],
-            space=ref_spaces,
-            autotop=config["autotop_labels"],
-            allow_missing=True,
-        )
-    else:
-        specs = expand(
-            bids(
-                root=root,
-                datatype="surf",
-                den="{density}",
+                suffix="{surfname}.surf.gii",
                 space="{space}",
                 hemi="{hemi}",
                 label="{autotop}",
-                suffix="surfaces.spec",
                 **config["subj_wildcards"],
             ),
             density=config["output_density"],
             space=ref_spaces,
             hemi=config["hemi"],
             autotop=config["autotop_labels"],
+            surfname=config["surf_types"]["hipp"],
             allow_missing=True,
         )
-    return specs
+    )
+    gii.extend(
+        expand(
+            bids(
+                root=root,
+                datatype="surf",
+                den="{density}",
+                suffix="{surfname}.surf.gii",
+                space="{space}",
+                hemi="{hemi}",
+                label="{autotop}",
+                **config["subj_wildcards"],
+            ),
+            density=config["output_density"],
+            space=ref_spaces,
+            hemi=config["hemi"],
+            autotop=config["autotop_labels"],
+            surfname=config["surf_types"]["dentate"],
+            allow_missing=True,
+        )
+    )
+    return gii
 
 
 def get_final_subfields():
@@ -313,6 +341,7 @@ def get_final_qc():
 def get_final_subj_output():
     subj_output = []
     subj_output.extend(get_final_spec())
+    subj_output.extend(get_final_surf())
     subj_output.extend(get_final_subfields())
     subj_output.extend(get_final_coords())
     subj_output.extend(get_final_transforms())

--- a/hippunfold/workflow/rules/warps.smk
+++ b/hippunfold/workflow/rules/warps.smk
@@ -167,7 +167,6 @@ rule create_warps_hipp:
         ),
         labelmap=get_labels_for_laplace,
     params:
-        interp_method="linear",
         gm_labels=lambda wildcards: config["laplace_labels"]["AP"]["gm"],
         epsilon=lambda wildcards: config["unfold_crop_epsilon_fractions"],
     resources:
@@ -226,8 +225,6 @@ rule create_warps_hipp:
             hemi="{hemi}",
             suffix="create_warps-hipp.txt"
         ),
-    container:
-        config["singularity"]["autotop"]
     script:
         "../scripts/create_warps.py"
 
@@ -294,7 +291,6 @@ rule create_warps_dentate:
         ),
         labelmap=get_labels_for_laplace,
     params:
-        interp_method="linear",
         gm_labels=lambda wildcards: config["laplace_labels"]["PD"]["sink"],
         epsilon=lambda wildcards: config["unfold_crop_epsilon_fractions"],
     resources:
@@ -353,8 +349,6 @@ rule create_warps_dentate:
             hemi="{hemi}",
             suffix="create_warps-dentate.txt"
         ),
-    container:
-        config["singularity"]["autotop"]
     script:
         "../scripts/create_warps.py"
 

--- a/hippunfold/workflow/rules/warps.smk
+++ b/hippunfold/workflow/rules/warps.smk
@@ -225,6 +225,8 @@ rule create_warps_hipp:
             hemi="{hemi}",
             suffix="create_warps-hipp.txt"
         ),
+    container:
+        config["singularity"]["autotop"]
     script:
         "../scripts/create_warps.py"
 
@@ -349,6 +351,8 @@ rule create_warps_dentate:
             hemi="{hemi}",
             suffix="create_warps-dentate.txt"
         ),
+    container:
+        config["singularity"]["autotop"]
     script:
         "../scripts/create_warps.py"
 

--- a/hippunfold/workflow/rules/warps.smk
+++ b/hippunfold/workflow/rules/warps.smk
@@ -168,7 +168,6 @@ rule create_warps_hipp:
         labelmap=get_labels_for_laplace,
     params:
         gm_labels=lambda wildcards: config["laplace_labels"]["AP"]["gm"],
-        epsilon=lambda wildcards: config["unfold_crop_epsilon_fractions"],
     resources:
         mem_mb=16000,
     output:
@@ -294,7 +293,6 @@ rule create_warps_dentate:
         labelmap=get_labels_for_laplace,
     params:
         gm_labels=lambda wildcards: config["laplace_labels"]["PD"]["sink"],
-        epsilon=lambda wildcards: config["unfold_crop_epsilon_fractions"],
     resources:
         mem_mb=16000,
     output:

--- a/hippunfold/workflow/scripts/create_warps.py
+++ b/hippunfold/workflow/scripts/create_warps.py
@@ -105,7 +105,7 @@ coord_flat_ap_unnorm = coord_flat_ap * unfold_dims[0]
 coord_flat_pd_unnorm = coord_flat_pd * unfold_dims[1]
 coord_flat_io_unnorm = coord_flat_io * unfold_dims[2]
 
-# get unfolded grid 
+# get unfolded grid
 
 points = np.stack(
     [

--- a/hippunfold/workflow/scripts/create_warps.py
+++ b/hippunfold/workflow/scripts/create_warps.py
@@ -105,26 +105,7 @@ coord_flat_ap_unnorm = coord_flat_ap * unfold_dims[0]
 coord_flat_pd_unnorm = coord_flat_pd * unfold_dims[1]
 coord_flat_io_unnorm = coord_flat_io * unfold_dims[2]
 
-# get unfolded grid (from 0 to 1, not world coords), using meshgrid:
-#  note: indexing='ij' to swap the ordering of x and y
-epsilon = snakemake.params.epsilon
-(unfold_gx, unfold_gy, unfold_gz) = np.meshgrid(
-    np.linspace(
-        0 + float(epsilon[0]), unfold_dims[0] - float(epsilon[0]), unfold_dims[0]
-    ),
-    np.linspace(
-        0 + float(epsilon[1]), unfold_dims[1] - float(epsilon[1]), unfold_dims[1]
-    ),
-    np.linspace(
-        0 + float(epsilon[2]), unfold_dims[2] - float(epsilon[2]), unfold_dims[2]
-    ),
-    indexing="ij",
-)
-summary("unfold_gx", unfold_gx)
-summary("unfold_gy", unfold_gy)
-summary("unfold_gz", unfold_gz)
-
-# perform the interpolation
+# get unfolded grid 
 
 points = np.stack(
     [
@@ -137,6 +118,10 @@ points = np.stack(
     ],
     axis=1,
 )
+summary("points", points)
+
+
+# perform the interpolation
 
 interp_ap = naturalneighbor.griddata(
     points,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ appdirs = "^1.4.4"
 Jinja2 = "^3.0.3"
 pygraphviz = "1.7"
 Pygments = "^2.10.0"
-naturalneighbor = "0.2.1"
 
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ appdirs = "^1.4.4"
 Jinja2 = "^3.0.3"
 pygraphviz = "1.7"
 Pygments = "^2.10.0"
+naturalneighbor = "0.2.1"
 
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
This PR adds only the best changes from https://github.com/khanlab/hippunfold/pull/300 and https://github.com/khanlab/hippunfold/pull/305. 

Notably, from https://github.com/khanlab/hippunfold/pull/300 no changes are kept except those that make surface config easier to use. Also interpolation is performed in 256x128x16 unfolded space instead of 0-1x0-1x0-1 unfolded space. Other changes are no longer needed since they are handled in https://github.com/khanlab/hippunfold/pull/305.

From https://github.com/khanlab/hippunfold/pull/305, here are the major changes:

Naturalneighbor interpolation is in create_warps.py. This lovely interpolation function is fast and initial tests show it working extremely well, solving all issues in https://github.com/khanlab/hippunfold/pull/300 without the need for any postprocessing of surfaces. I tried many things to clean these surfaces, including different interpolation functions, but I believe this fix now finally solves the root cause.

This is a breaking change since outputs will now be slightly different (and better quality). I see no downsides or anticipated conflicts.

This is also now in-line with the original Matlab code that was used for interpolation ([hippo_autotop](https://github.com/jordandekraker/Hippocampal_AutoTop))

Still doing a wet-run test.