### PR TITLE
Template inject Lflip vs R

### DIFF
--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -384,21 +384,25 @@ template_based_segmentation:
     hemi:
       - R
       - L
-  CIVM:
+  dHCP:
     hemi:
       - R
       - L
+
   MBMv2:
     hemi:
       - R
   MBMv3:
     hemi:
       - R
-  ABAv3:
+  CIVM:
     hemi:
       - R
       - L
-  dHCP:
+  upenn:
+    hemi:
+      - R
+  ABAv3:
     hemi:
       - R
       - L

--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -151,6 +151,7 @@ parse_args:
       - 'MBMv3'
       - 'CIVM'
       - 'ABAv3'
+      - 'bigbrain'
     default: 'CITI168'
     help: 'Set the template to use for registration to coronal oblique (and optionally for template-based segmentation if --use-template-seg is enabled). CITI168 is for adult human data, dHCP is for neonatal human data, MBMv2 is for ex vivo marmoset data, MBMv3 is for in vivo marmoset data, CIVM is for in vivo macaque data, and ABAv3 is for mouse data. When using a non-human template, consider using a corresponding atlas. (default: %(default)s)'
 
@@ -164,6 +165,7 @@ parse_args:
       - 'MBMv3'
       - 'CIVM'
       - 'ABAv3'
+      - 'bigbrain'
     default: 'upenn'
     help: 'Set the template to use for shape injection. (default: %(default)s)'
 
@@ -400,7 +402,10 @@ template_based_segmentation:
     hemi:
       - R
       - L
-
+  bigbrain:
+    hemi:
+      - R
+      - L
 
 template_files:
   CITI168:
@@ -455,6 +460,13 @@ template_files:
     Mask_crop: tpl-ABAv3_hemi-{hemi}_space-corobl_desc-tissuemanual_dseg.nii.gz
     dseg: tpl-ABAv3_hemi-{hemi}_space-corobl_desc-tissuemanual_dseg.nii.gz
     coords: tpl-ABAv3_dir-{dir}_hemi-{hemi}_space-corobl_label-{autotop}_desc-laplace_coords.nii.gz
+  bigbrain:
+    T1w: tpl-bbhist_100um_T1w.nii.gz
+    xfm_corobl: tpl-bbhist_from-native_to-corobl_type-itk_affine.txt
+    crop_ref: tpl-bbhist_hemi-{hemi}_space-corobl_desc-tissuemanual_40um_dseg.nii.gz
+    Mask_crop: tpl-bbhist_hemi-{hemi}_space-corobl_desc-tissuemanual_40um_dseg.nii.gz
+    dseg: tpl-bbhist_hemi-{hemi}_space-corobl_desc-tissuemanual_40um_dseg.nii.gz
+    coords: tpl-bbhist_dir-{dir}_hemi-{hemi}_space-corobl_label-{autotop}_desc-laplace_coords.nii.gz
 
 atlas_files:
   multihist7:
@@ -558,6 +570,7 @@ resource_urls:
     upenn: 'files.ca-1.osf.io/v1/resources/v8acf/providers/osfstorage/65395c1613d27b122a94ca09/?zip='
     CIVM: 'files.ca-1.osf.io/v1/resources/v8acf/providers/osfstorage/65395bf62827451220b86e24/?zip='
     ABAv3: 'files.ca-1.osf.io/v1/resources/v8acf/providers/osfstorage/6668855b6b6c8e2cc704ca97/?zip='
+    bigbrain: 'files.ca-1.osf.io/v1/resources/v8acf/providers/osfstorage/666b1bc765e1de5972893e59/?zip='
 #to get hash, see https://github.com/CenterForOpenScience/osf.io/issues/8256#issuecomment-379833911
 
 

--- a/hippunfold/workflow/rules/shape_inject.smk
+++ b/hippunfold/workflow/rules/shape_inject.smk
@@ -51,7 +51,7 @@ def get_input_for_shape_inject(wildcards):
                 suffix="dseg.nii.gz",
                 space="corobl",
                 hemi="{hemi}",
-                from_="{modality_suffix}"
+                from_="{modality_suffix}",
             ).format(**wildcards, modality_suffix=modality_suffix),
         )
     else:
@@ -87,7 +87,7 @@ def get_input_splitseg_for_shape_inject(wildcards):
             suffix="dsegsplit",
             space="corobl",
             hemi="{hemi}",
-            from_="{modality_suffix}"
+            from_="{modality_suffix}",
         ).format(**wildcards, modality_suffix=modality_suffix)
     else:
         seg = bids(
@@ -100,7 +100,6 @@ def get_input_splitseg_for_shape_inject(wildcards):
             hemi="{hemi}",
         ).format(**wildcards)
     return seg
-
 
 
 rule prep_segs_for_greedy:


### PR DESCRIPTION
I noticed that when using `--inject_template bigbrain`, only the hemi-R template was being used (with the hemi-L segmentation image) when actually both L and R are available from this template. I fixed this with the same logic as the new `templateseg.smk` logic.

Waiting for me new wetrun cases to finish