### PR TITLE
FIX: hipp curvature was being used always, instead of wildcard

### DIFF
--- a/hippunfold/workflow/rules/gifti.smk
+++ b/hippunfold/workflow/rules/gifti.smk
@@ -978,7 +978,7 @@ rule normalize_curvature2:
             space="{space}",
             hemi="{hemi}",
             desc="unnorm",
-            label="hipp",
+            label="{autotop}",
             **config["subj_wildcards"]
         ),
     output:


### PR DESCRIPTION
this didn't affect any workflow computations, just the subsequent dscalar.nii and spec file that would have the wrong curvature map