### PR TITLE
bug fixes to branch

### DIFF
--- a/hippunfold/pipeline_description.json
+++ b/hippunfold/pipeline_description.json
@@ -4,11 +4,11 @@
   "DatasetType": "derivative",
   "GeneratedBy": [
     {
-      "Name": "hippunfold",
-      "Version": "1.5.4",
-      "CodeURL": "https://github.com/khanlab/hippunfold",
-      "Author": "Jordan DeKraker & Ali Khan",
-      "AuthorEmail": "ali.khan@uwo.ca"
-    }
-  ]
+        "Name": "hippunfold",
+        "Version": "1.5.2-pre.2",
+        "CodeURL": "https://github.com/khanlab/hippunfold",
+        "Author": "Jordan DeKraker & Ali Khan",
+        "AuthorEmail": "ali.khan@uwo.ca"
+        }
+    ]
 }

--- a/hippunfold/workflow/rules/gifti.smk
+++ b/hippunfold/workflow/rules/gifti.smk
@@ -978,7 +978,7 @@ rule normalize_curvature2:
             space="{space}",
             hemi="{hemi}",
             desc="unnorm",
-            label="hipp",
+            label="{autotop}",
             **inputs.subj_wildcards
         ),
     output:


### PR DESCRIPTION
* fix for using T1T2w model

run_inference was only accepting a single input image, this makes it accept a list of images too, and makes it so --force-nnunet-model T1T2w grabs both T1w and T2w as inputs.

* hipp curvature was being used always, instead of wildcard

this didn't affect any workflow computations, just the subsequent dscalar.nii and spec file that would have the wrong curvature map

* fix logical error

* Bump version to 1.5.2-pre.1

* Bump version to 1.5.2-pre.2

* keep pipeline_description changes

---------