### PR TITLE
Conda dependencies

### DIFF
--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -255,12 +255,8 @@ parse_args:
     help: 'Hemisphere(s) to process (default: %(default)s)'
 
   --laminar_coords_method:
-    choices:
-      - 'laplace'
-      - 'equivolume'
-    default:
-      - 'equivolume'
-    help: 'Method to use for laminar coordinates. Equivolume uses equivolumetric layering from Waehnert et al 2014 (Nighres implementation). (default: %(default)s)' 
+    default: 'laplace'
+    help: 'Method to use for laminar coordinates. (default: %(default)s)' 
 
   --autotop_labels:
     choices:
@@ -674,7 +670,7 @@ hemi:
 output_density:
   - 0p5mm
 
-laminar_coords_method: equivolume
+laminar_coords_method: laplace
 skip_preproc: False
 plugins.validator.skip: False
 nnunet_enable_tta: False


### PR DESCRIPTION
This PR removes the `equivolume` logic from the laminar coordinate method, effectively eliminating hippunfold's dependency on the `nighres` package. This change serves as a stepping stone toward synchronizing and integrating hippunfold with the conda environment.