### PR TITLE
Behaviour and location of workdir, and removing hippunfold/ toplevel folder

### DIFF
--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -264,11 +264,6 @@ parse_args:
     nargs: '+'
     help: 'Run hipp (CA + subiculum) alone or include dentate (default: %(default)s)'
 
-  --workdir:
-    help: 'Folder for storing working files, if not specified, will make a temporary folder with tempfile.mkdtemp() (default: %(default)s)'
-    default: None
-    type: Path
-
   --force_nnunet_model:
     help: 'Force nnunet model to use (expert option). (default: %(default)s)'
     default: False
@@ -293,6 +288,14 @@ parse_args:
     dest: "plugins.validator.skip"
     action: "store_false"
     default: True
+
+  --workdir:
+    help: |
+      Folder for storing working files. If not specified, a temporary folder
+      will be made in your system's temp directory (e.g. /tmp). You can also
+      use environment variables when setting the workdir, e.g. --workdir '$SLURM_TMPDIR'.
+    default: null
+    type: str
 
 
   --version:

--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -264,10 +264,10 @@ parse_args:
     nargs: '+'
     help: 'Run hipp (CA + subiculum) alone or include dentate (default: %(default)s)'
 
-  --keep_work:
-    help: 'Keep work folder intact instead of archiving it for each subject (default: %(default)s)'
-    default: False
-    action: 'store_true'
+  --workdir:
+    help: 'Folder for storing working files, if not specified, will make a temporary folder with tempfile.mkdtemp() (default: %(default)s)'
+    default: None
+    type: Path
 
   --force_nnunet_model:
     help: 'Force nnunet model to use (expert option). (default: %(default)s)'
@@ -693,6 +693,7 @@ t1_reg_template: False
 generate_myelin_map: False
 no_unfolded_reg: False
 root: results
+workdir: null
 use_template_seg: False
 template_seg_smoothing_factor: 2
 native_surf: False

--- a/hippunfold/workflow/Snakefile
+++ b/hippunfold/workflow/Snakefile
@@ -4,6 +4,7 @@ import snakebids
 from snakebids import bids, set_bids_spec
 from tempfile import mkdtemp
 
+
 configfile: "config/snakebids.yml"
 
 
@@ -94,13 +95,11 @@ wildcard_constraints:
     template="[a-zA-Z0-9]+",
 
 
-#root = os.path.normpath(os.path.join(config["root"], "hippunfold"))
-#work = os.path.normpath(os.path.join(config["root"], "work"))
-
-root = os.path.expandvars(config["root"])
 if config["workdir"] == None:
     config["workdir"] = mkdtemp()
 work = os.path.expandvars(config["workdir"])
+root = os.path.expandvars(config["root"])
+
 
 include: "rules/common.smk"
 include: "rules/download.smk"

--- a/hippunfold/workflow/Snakefile
+++ b/hippunfold/workflow/Snakefile
@@ -2,7 +2,7 @@
 
 import snakebids
 from snakebids import bids, set_bids_spec
-
+from tempfile import mkdtemp
 
 configfile: "config/snakebids.yml"
 
@@ -94,9 +94,13 @@ wildcard_constraints:
     template="[a-zA-Z0-9]+",
 
 
-root = os.path.normpath(os.path.join(config["root"], "hippunfold"))
-work = os.path.normpath(os.path.join(config["root"], "work"))
+#root = os.path.normpath(os.path.join(config["root"], "hippunfold"))
+#work = os.path.normpath(os.path.join(config["root"], "work"))
 
+root = os.path.expandvars(config["root"])
+if config["workdir"] == None:
+    config["workdir"] = mkdtemp()
+work = os.path.expandvars(config["workdir"])
 
 include: "rules/common.smk"
 include: "rules/download.smk"

--- a/hippunfold/workflow/rules/common.smk
+++ b/hippunfold/workflow/rules/common.smk
@@ -376,7 +376,6 @@ if "corobl" in ref_spaces:
             "cp {input} {output}"
 
 
-
 def get_download_dir():
     if "HIPPUNFOLD_CACHE_DIR" in os.environ.keys():
         download_dir = os.environ["HIPPUNFOLD_CACHE_DIR"]
@@ -385,5 +384,3 @@ def get_download_dir():
         dirs = AppDirs("hippunfold", "khanlab")
         download_dir = dirs.user_cache_dir
     return download_dir
-
-


### PR DESCRIPTION
Previously, each hippunfold output directory would contain hippunfold and work sub-directories. This moves the work folder to a temporary location (e.g. a folder in /tmp), and then removes the extra top-level hippunfold folder. That extra folder level isn't really needed removing it makes hippunfold more bids-derivatives compliant. 

There is no automatic archiving of the work directory anymore as well, so the --keep-work option is removed. We also have a new CLI option for setting the location of the workdir.  By default, the files in work are not deleted by snakemake, so the user could keep them by setting --workdir appropriately, or point it to e.g. $SLURM_TMPDIR. 

We can also make use of the temp() directive in the workflow to have snakemake delete the files after they are no longer needed, which can be disabled with --notemp. I don't think its really critical to do that though, since the workdir can be put in a place where the system will delete them later.. 