### PR TITLE
Add support for new workbench structure labels

### DIFF
--- a/hippunfold/workflow/rules/common.smk
+++ b/hippunfold/workflow/rules/common.smk
@@ -48,36 +48,11 @@ def get_final_spec():
                 datatype="surf",
                 den="{density}",
                 space="{space}",
-                hemi="{hemi}",
-                label="{autotop}",
                 suffix="surfaces.spec",
                 **inputs.subj_wildcards,
             ),
             density=config["output_density"],
             space=ref_spaces,
-            hemi=config["hemi"],
-            autotop=config["autotop_labels"],
-            surfname=config["surf_types"]["hipp"],
-            allow_missing=True,
-        )
-    )
-    specs.extend(
-        inputs[config["modality"]].expand(
-            bids(
-                root=root,
-                datatype="surf",
-                den="{density}",
-                space="{space}",
-                hemi="{hemi}",
-                label="{autotop}",
-                suffix="surfaces.spec",
-                **inputs.subj_wildcards,
-            ),
-            density=config["output_density"],
-            space=ref_spaces,
-            hemi=config["hemi"],
-            autotop=config["autotop_labels"],
-            surfname=config["surf_types"]["dentate"],
             allow_missing=True,
         )
     )
@@ -87,15 +62,10 @@ def get_final_spec():
                 root=root,
                 datatype="surf",
                 space="{space}",
-                hemi="{hemi}",
-                label="{autotop}",
                 suffix="surfaces.spec",
                 **inputs.subj_wildcards,
             ),
             space="corobl",
-            hemi=config["hemi"],
-            autotop=config["autotop_labels"],
-            surfname=config["surf_types"]["hipp"],
             allow_missing=True,
         )
     )
@@ -306,7 +276,7 @@ if "corobl" in ref_spaces:
         input:
             os.path.join(work, "{pre}_space-corobl_{post}{suffix}.{ext}"),
         output:
-            os.path.join(root, "{pre}_space-corobl_{post}{suffix,coords}.{ext}"),
+            os.path.join(root, "{pre,[^/].+}_space-corobl_{post}{suffix,coords}.{ext}"),
         group:
             "subj"
         shell:
@@ -316,7 +286,9 @@ if "corobl" in ref_spaces:
         input:
             os.path.join(work, "{pre}_{fromto,from|to}-corobl_{post}{suffix}.{ext}"),
         output:
-            os.path.join(root, "{pre}_{fromto,from|to}-corobl_{post}{suffix,xfm}.{ext}"),
+            os.path.join(
+                root, "{pre,[^/].+}_{fromto,from|to}-corobl_{post}{suffix,xfm}.{ext}"
+            ),
         group:
             "subj"
         shell:
@@ -326,7 +298,7 @@ if "corobl" in ref_spaces:
         input:
             os.path.join(work, "{pre}_desc-subfields_{post}{suffix}.{ext}"),
         output:
-            os.path.join(root, "{pre}_desc-subfields_{post}{suffix,dseg}.{ext}"),
+            os.path.join(root, "{pre,[^/].+}_desc-subfields_{post}{suffix,dseg}.{ext}"),
         group:
             "subj"
         shell:

--- a/hippunfold/workflow/rules/gifti.smk
+++ b/hippunfold/workflow/rules/gifti.smk
@@ -1,9 +1,24 @@
 # lookup tables for structure:
 hemi_to_structure = {"L": "CORTEX_LEFT", "R": "CORTEX_RIGHT"}
+
+
+def get_structure(hemi, label):
+    if label == "hipp":
+        if hemi == "L":
+            return "HIPPOCAMPUS_LEFT"
+        elif hemi == "R":
+            return "HIPPOCAMPUS_RIGHT"
+    elif label == "dentate":
+        if hemi == "L":
+            return "HIPPOCAMPUS_DENTATE_LEFT"
+        elif hemi == "R":
+            return "HIPPOCAMPUS_DENTATE_RIGHT"
+
+
 surf_to_secondary_type = {
     "midthickness": "MIDTHICKNESS",
-    "inner": "PIAL",
-    "outer": "GRAY_WHITE",
+    "inner": "INNER",
+    "outer": "OUTER",
 }
 
 
@@ -18,7 +33,9 @@ rule cp_template_to_unfold:
             "tpl-avg_space-unfold_den-{density}_{surfname}.surf.gii",
         ),
     params:
-        structure_type=lambda wildcards: hemi_to_structure[wildcards.hemi],
+        structure_type=lambda wildcards: get_structure(
+            wildcards.hemi, wildcards.autotop
+        ),
         secondary_type=lambda wildcards: surf_to_secondary_type[wildcards.surfname],
         surface_type="FLAT",
     output:
@@ -59,7 +76,9 @@ rule calc_unfold_template_coords:
         coord_IO="coord-IO.shape.gii",
         origin=lambda wildcards: config["{autotop}"]["origin"],
         extent=lambda wildcards: config["{autotop}"]["extent"],
-        structure_type=lambda wildcards: hemi_to_structure[wildcards.hemi],
+        structure_type=lambda wildcards: get_structure(
+            wildcards.hemi, wildcards.autotop
+        ),
     output:
         coords_gii=bids(
             root=work,

--- a/hippunfold/workflow/rules/native_surf.smk
+++ b/hippunfold/workflow/rules/native_surf.smk
@@ -921,7 +921,7 @@ rule pad_unfold_ref:
         for this)."""
     input:
         ref_nii=bids(
-            root=root,
+            root=work,
             space="unfold",
             label="{label}",
             datatype="warps",
@@ -1360,33 +1360,29 @@ rule convert_unfoldreg_warp_from_itk_to_world:
         "wb_command -convert-warpfield -from-itk {input} -to-world {output}"
 
 
-def get_unfold_ref(wildcards):
-    """function to return either unfoldreg or unfold ref mesh, depending on whether
-    unfoldreg can be performed (based on atlas wildcards)"""
-
+def get_unfold_ref_name(wildcards):
     if (
         wildcards.label in config["atlas_files"][config["atlas"]]["label_wildcards"]
         and config["no_unfolded_reg"] == False
     ):
-        return bids(
-            root=root,
-            datatype="surf",
-            suffix="midthickness.surf.gii",
-            space="unfoldreg",
-            hemi="{hemi}",
-            label="{label}",
-            **inputs.subj_wildcards
-        )
+        return "unfoldreg"
     else:
-        return bids(
-            root=root,
-            datatype="surf",
-            suffix="midthickness.surf.gii",
-            space="unfold",
-            hemi="{hemi}",
-            label="{label}",
-            **inputs.subj_wildcards
-        )
+        return "unfold"
+
+
+def get_unfold_ref(wildcards):
+    """function to return either unfoldreg or unfold ref mesh, depending on whether
+    unfoldreg can be performed (based on atlas wildcards)"""
+
+    return bids(
+        root=root,
+        datatype="surf",
+        suffix="midthickness.surf.gii",
+        space=get_unfold_ref_name(wildcards),
+        hemi="{hemi}",
+        label="{label}",
+        **inputs.subj_wildcards
+    )
 
 
 rule warp_unfold_native_to_unfoldreg:
@@ -1623,7 +1619,7 @@ rule atlas_label_to_unfold_nii:
     input:
         atlas_dir=lambda wildcards: Path(download_dir) / "atlas" / wildcards.atlas,
         ref_nii=bids(
-            root=root,
+            root=work,
             space="unfold",
             label="{label}",
             datatype="warps",
@@ -1805,7 +1801,7 @@ rule create_spec_file_hipp_native:
             atlas=config["atlas"],
             allow_missing=True,
         ),
-        surfs=expand(
+        surfs=lambda wildcards: expand(
             bids(
                 root=root,
                 datatype="surf",
@@ -1816,7 +1812,7 @@ rule create_spec_file_hipp_native:
                 **inputs.subj_wildcards
             ),
             surfname=["midthickness"],
-            space=["{space}", "unfold", "unfoldreg"],
+            space=["{space}", get_unfold_ref_name(wildcards)],
             allow_missing=True,
         ),
         cifti_metrics=lambda wildcards: inputs[config["modality"]].expand(
@@ -1879,7 +1875,7 @@ rule create_spec_file_dentate_native:
             metric=get_gifti_metric_types(wildcards.label),
             allow_missing=True,
         ),
-        surfs=expand(
+        surfs=lambda wildcards: expand(
             bids(
                 root=root,
                 datatype="surf",
@@ -1890,7 +1886,7 @@ rule create_spec_file_dentate_native:
                 **inputs.subj_wildcards
             ),
             surfname=["midthickness"],
-            space=["{space}", "unfold", "unfoldreg"],
+            space=["{space}", get_unfold_ref_name(wildcards)],
             allow_missing=True,
         ),
         cifti_metrics=lambda wildcards: inputs[config["modality"]].expand(
@@ -1923,6 +1919,72 @@ rule create_spec_file_dentate_native:
         "subj"
     shell:
         "{params.cmds}"
+
+
+rule merge_lr_spec_file:
+    input:
+        spec_files=expand(
+            bids(
+                root=root,
+                datatype="surf",
+                suffix="surfaces.spec",
+                hemi="{hemi}",
+                space="{space}",
+                label="{autotop}",
+                **inputs.subj_wildcards
+            ),
+            hemi=config["hemi"],
+            allow_missing=True,
+        ),
+    params:
+        cmd=get_cmd_merge_spec,
+    output:
+        spec_file=bids(
+            root=root,
+            datatype="surf",
+            space="{space}",
+            suffix="surfaces.spec",
+            label="{autotop}",
+            **inputs.subj_wildcards
+        ),
+    container:
+        config["singularity"]["autotop"]
+    group:
+        "subj"
+    shell:
+        "{params.cmd}"
+
+
+rule merge_hipp_dentate_spec_file:
+    input:
+        spec_files=expand(
+            bids(
+                root=root,
+                datatype="surf",
+                suffix="surfaces.spec",
+                space="{space}",
+                label="{autotop}",
+                **inputs.subj_wildcards
+            ),
+            autotop=config["autotop_labels"],
+            allow_missing=True,
+        ),
+    params:
+        cmd=get_cmd_merge_spec,
+    output:
+        spec_file=bids(
+            root=root,
+            datatype="surf",
+            space="{space}",
+            suffix="surfaces.spec",
+            **inputs.subj_wildcards
+        ),
+    container:
+        config["singularity"]["autotop"]
+    group:
+        "subj"
+    shell:
+        "{params.cmd}"
 
 
 rule cp_native_surf_to_root:

--- a/hippunfold/workflow/rules/native_surf.smk
+++ b/hippunfold/workflow/rules/native_surf.smk
@@ -238,7 +238,7 @@ rule update_native_mesh_structure:
             **inputs.subj_wildcards
         ),
     params:
-        structure_type=lambda wildcards: hemi_to_structure[wildcards.hemi],
+        structure_type=lambda wildcards: get_structure(wildcards.hemi, wildcards.label),
         secondary_type=lambda wildcards: surf_to_secondary_type[wildcards.surfname],
         surface_type="ANATOMICAL",
     output:
@@ -320,7 +320,7 @@ rule warp_native_mesh_to_unfold:
             mode="surface"
         ),
     params:
-        structure_type=lambda wildcards: hemi_to_structure[wildcards.hemi],
+        structure_type=lambda wildcards: get_structure(wildcards.hemi, wildcards.label),
         secondary_type=lambda wildcards: surf_to_secondary_type[wildcards.surfname],
         surface_type="FLAT",
     output:
@@ -699,7 +699,7 @@ rule warp_midthickness_to_inout:
             **inputs.subj_wildcards
         ),
     params:
-        structure_type=lambda wildcards: hemi_to_structure[wildcards.hemi],
+        structure_type=lambda wildcards: get_structure(wildcards.hemi, wildcards.label),
         secondary_type=lambda wildcards: surf_to_secondary_type[wildcards.surfname],
         surface_type="ANATOMICAL",
     output:
@@ -1414,7 +1414,7 @@ rule warp_unfold_native_to_unfoldreg:
             **inputs.subj_wildcards,
         ),
     params:
-        structure_type=lambda wildcards: hemi_to_structure[wildcards.hemi],
+        structure_type=lambda wildcards: get_structure(wildcards.hemi, wildcards.label),
         secondary_type=lambda wildcards: surf_to_secondary_type[wildcards.surfname],
         surface_type="FLAT",
     output:

--- a/hippunfold/workflow/rules/warps.smk
+++ b/hippunfold/workflow/rules/warps.smk
@@ -242,7 +242,7 @@ rule create_unfold_ref:
         orient=lambda wildcards: config["unfold_vol_ref"][wildcards.autotop]["orient"],
     output:
         nii=bids(
-            root=root,
+            root=work,
             space="unfold",
             label="{autotop}",
             datatype="warps",
@@ -261,7 +261,7 @@ rule create_unfold_ref:
 rule create_unfold_coord_map:
     input:
         nii=bids(
-            root=root,
+            root=work,
             space="unfold",
             label="{autotop}",
             datatype="warps",
@@ -316,7 +316,7 @@ def get_laminar_coords(wildcards):
 rule create_warps_hipp:
     input:
         unfold_ref_nii=bids(
-            root=root,
+            root=work,
             space="unfold",
             label="hipp",
             datatype="warps",
@@ -409,7 +409,7 @@ rule create_warps_hipp:
 rule create_warps_dentate:
     input:
         unfold_ref_nii=bids(
-            root=root,
+            root=work,
             space="unfold",
             label="dentate",
             datatype="warps",


### PR DESCRIPTION
Replaces CORTEX_LEFT with HIPPOCAMPUS_LEFT, and HIPPOCAMPUS_DENTATE_LEFT, ...
The dev version of workbench is used in the container now (don't forget to re-pull if you have already run from the unfoldregv2 branch). 

Also makes new merged ciftis with multiple structures (eg hippocampus + dentate together)

Includes a bug fix for some of the generic copy rules, and moving all the remaining warps files to work (eliminates that folder)..
