### PR TITLE
Workdir now set to `work` by default

### DIFF
--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -291,10 +291,10 @@ parse_args:
 
   --workdir:
     help: |
-      Folder for storing working files. If not specified, a temporary folder
-      will be made in your system's temp directory (e.g. /tmp). You can also
-      use environment variables when setting the workdir, e.g. --workdir '$SLURM_TMPDIR'.
-    default: null
+      Folder for storing working files. If not specified, will be in "work/" subfolder 
+      in the output folder. You can also use environment variables when setting the 
+      workdir, e.g. --workdir '$SLURM_TMPDIR'.
+    default: work
     type: str
 
 

--- a/hippunfold/workflow/Snakefile
+++ b/hippunfold/workflow/Snakefile
@@ -95,8 +95,6 @@ wildcard_constraints:
     template="[a-zA-Z0-9]+",
 
 
-if config["workdir"] == None:
-    config["workdir"] = mkdtemp()
 work = os.path.expandvars(config["workdir"])
 root = os.path.expandvars(config["root"])
 


### PR DESCRIPTION
Was causing a number of issues because it was using /tmp and also a new folder for each run..

This makes it a subfolder of the output folder like it used to be, though we don't archive it up by default.. 
I'll merge this in without much review so things don't stay broken, but we can revisit how temporary files are dealt with in a later PR..