### PR TITLE
add decimation and clean_method params for gen_isosurface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
 parts/
 sdist/

--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -688,6 +688,7 @@ laplace_labels:
         - 8
       src:
         - 1
+        - 3
       sink:
         - 2
         - 4

--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -660,7 +660,6 @@ laplace_labels:
     IO:
       gm:
         - 1
-        - 8
       src:
         - 2
         - 4

--- a/hippunfold/workflow/Snakefile
+++ b/hippunfold/workflow/Snakefile
@@ -120,26 +120,12 @@ if config["modality"] == "hippb500":
 
 
 include: "rules/coords.smk"
-
-
 include: "rules/warps.smk"
-
-
 include: "rules/gifti.smk"
-
-
 include: "rules/subfields.smk"
-
-
 include: "rules/resample_final_to_crop_native.smk"
-
-
 include: "rules/qc.smk"
-
-
 include: "rules/myelin_map.smk"
-
-
 include: "rules/native_surf.smk"
 
 

--- a/hippunfold/workflow/Snakefile
+++ b/hippunfold/workflow/Snakefile
@@ -120,12 +120,26 @@ if config["modality"] == "hippb500":
 
 
 include: "rules/coords.smk"
+
+
 include: "rules/warps.smk"
+
+
 include: "rules/gifti.smk"
+
+
 include: "rules/subfields.smk"
+
+
 include: "rules/resample_final_to_crop_native.smk"
+
+
 include: "rules/qc.smk"
+
+
 include: "rules/myelin_map.smk"
+
+
 include: "rules/native_surf.smk"
 
 

--- a/hippunfold/workflow/lib/utils.py
+++ b/hippunfold/workflow/lib/utils.py
@@ -1,14 +1,17 @@
 import logging
 import sys
 
+
 def setup_logger(log_file=None):
     logger = logging.getLogger(__name__)
     logger.setLevel(logging.INFO)
 
-    formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+    formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
 
-    handler = logging.FileHandler(log_file) if log_file else logging.StreamHandler(sys.stderr)
+    handler = (
+        logging.FileHandler(log_file) if log_file else logging.StreamHandler(sys.stderr)
+    )
     handler.setFormatter(formatter)
-    
+
     logger.addHandler(handler)
     return logger

--- a/hippunfold/workflow/lib/utils.py
+++ b/hippunfold/workflow/lib/utils.py
@@ -1,0 +1,14 @@
+import logging
+import sys
+
+def setup_logger(log_file=None):
+    logger = logging.getLogger(__name__)
+    logger.setLevel(logging.INFO)
+
+    formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+
+    handler = logging.FileHandler(log_file) if log_file else logging.StreamHandler(sys.stderr)
+    handler.setFormatter(formatter)
+    
+    logger.addHandler(handler)
+    return logger

--- a/hippunfold/workflow/rules/common.smk
+++ b/hippunfold/workflow/rules/common.smk
@@ -219,7 +219,7 @@ def get_final_output():
 
 if "corobl" in ref_spaces:
 
-    ruleorder: laplace_beltrami > laynii_layers > copy_coords_to_results
+    ruleorder: laplace_beltrami > laynii_layers_equidist > laynii_layers_equivol > copy_coords_to_results
 
     rule copy_coords_to_results:
         input:

--- a/hippunfold/workflow/rules/coords.smk
+++ b/hippunfold/workflow/rules/coords.smk
@@ -231,7 +231,46 @@ rule prep_dseg_for_laynii:
         "c3d -background -1 {input} -as DSEG -retain-labels {params.gm_labels} -binarize -scale 3 -popas GM -push DSEG -retain-labels {params.src_labels} -binarize -scale 2 -popas WM -push DSEG -retain-labels {params.sink_labels} -binarize -scale 1 -popas PIAL -push GM -push WM -add -push PIAL -add -o {output}"
 
 
-rule laynii_layers:
+rule laynii_layers_equidist:
+    input:
+        dseg_rim=bids(
+            root=work,
+            datatype="anat",
+            **inputs.subj_wildcards,
+            suffix="dseg.nii.gz",
+            dir="{dir}",
+            desc="laynii",
+            label="{autotop}",
+            space="corobl",
+            hemi="{hemi}",
+        ),
+    output:
+        equidist=bids(
+            root=work,
+            datatype="coords",
+            dir="{dir,IO}",
+            label="{autotop}",
+            suffix="coords.nii.gz",
+            desc="equidist",
+            space="corobl",
+            hemi="{hemi}",
+            **inputs.subj_wildcards,
+        ),
+    shadow:
+        "minimal"
+    container:
+        config["singularity"]["autotop"]
+    conda:
+        "../envs/laynii.yaml"
+    group:
+        "subj"
+    shell:
+        "cp {input} dseg.nii.gz && "
+        "LN2_LAYERS  -rim dseg.nii.gz && "
+        "cp dseg_metric_equidist.nii.gz {output.equidist}"
+
+
+rule laynii_layers_equivol:
     input:
         dseg_rim=bids(
             root=work,
@@ -256,17 +295,6 @@ rule laynii_layers:
             hemi="{hemi}",
             **inputs.subj_wildcards,
         ),
-        equidist=bids(
-            root=work,
-            datatype="coords",
-            dir="{dir,IO}",
-            label="{autotop}",
-            suffix="coords.nii.gz",
-            desc="equidist",
-            space="corobl",
-            hemi="{hemi}",
-            **inputs.subj_wildcards,
-        ),
     shadow:
         "minimal"
     container:
@@ -278,7 +306,6 @@ rule laynii_layers:
     shell:
         "cp {input} dseg.nii.gz && "
         "LN2_LAYERS  -rim dseg.nii.gz -equivol && "
-        "cp dseg_metric_equidist.nii.gz {output.equidist} && "
         "cp dseg_metric_equivol.nii.gz {output.equivol}"
 
 

--- a/hippunfold/workflow/rules/native_surf.smk
+++ b/hippunfold/workflow/rules/native_surf.smk
@@ -70,6 +70,7 @@ rule gen_native_mesh:
             "preserve_topology": True,
             "boundary_vertex_deletion": False,
         },
+	decimation_target = 0.1 #mm
         clean_method="cleanAK",  #cleanAK or cleanJD 
         morph_openclose_dist=2,  # mm
         coords_epsilon=0.1,

--- a/hippunfold/workflow/rules/native_surf.smk
+++ b/hippunfold/workflow/rules/native_surf.smk
@@ -70,7 +70,7 @@ rule gen_native_mesh:
             "preserve_topology": True,
             "boundary_vertex_deletion": False,
         },
-	decimation_target = 0.1 #mm
+        decimation_target=0.1,  #mm
         clean_method="cleanAK",  #cleanAK or cleanJD 
         morph_openclose_dist=2,  # mm
         coords_epsilon=0.1,

--- a/hippunfold/workflow/rules/native_surf.smk
+++ b/hippunfold/workflow/rules/native_surf.smk
@@ -66,10 +66,9 @@ rule gen_native_mesh:
     params:
         threshold=lambda wildcards: surf_thresholds[wildcards.surfname],
         decimate_opts={
-            "reduction": 0.1,
+            "reduction": 0.5,
             "feature_angle": 25,
             "preserve_topology": True,
-            "boundary_vertex_deletion": False,
         },
         hole_fill_radius=0.1,
         clean_method="cleanAK",  #cleanAK or cleanJD 

--- a/hippunfold/workflow/rules/native_surf.smk
+++ b/hippunfold/workflow/rules/native_surf.smk
@@ -66,11 +66,12 @@ rule gen_native_mesh:
     params:
         threshold=lambda wildcards: surf_thresholds[wildcards.surfname],
         decimate_opts={
-            "reduction": 0.2,
+            "reduction": 0.1,
+            "feature_angle": 25,
             "preserve_topology": True,
             "boundary_vertex_deletion": False,
         },
-        decimation_target=0.1,  #mm
+        hole_fill_radius=0.1,
         clean_method="cleanAK",  #cleanAK or cleanJD 
         morph_openclose_dist=2,  # mm
         coords_epsilon=0.1,

--- a/hippunfold/workflow/rules/native_surf.smk
+++ b/hippunfold/workflow/rules/native_surf.smk
@@ -65,7 +65,12 @@ rule gen_native_mesh:
         ),
     params:
         threshold=lambda wildcards: surf_thresholds[wildcards.surfname],
-        decimate_percent=0,  # not enabled
+        decimate_opts={
+            "reduction": 0.1,
+            "preserve_topology": True,
+            "boundary_vertex_deletion": False,
+        },  #0.3 reduction seems to solve resampling memory issue
+        clean_method="cleanAK",  #cleanAK or cleanJD 
         morph_openclose_dist=2,  # mm
         coords_epsilon=0.1,
     output:

--- a/hippunfold/workflow/rules/native_surf.smk
+++ b/hippunfold/workflow/rules/native_surf.smk
@@ -367,7 +367,7 @@ rule compute_halfthick_mask:
             dir="IO",
             label="{label}",
             suffix="coords.nii.gz",
-            desc="equivol",
+            desc=config["laminar_coords_method"],
             space="corobl",
             hemi="{hemi}",
             **inputs.subj_wildcards,

--- a/hippunfold/workflow/rules/native_surf.smk
+++ b/hippunfold/workflow/rules/native_surf.smk
@@ -66,10 +66,10 @@ rule gen_native_mesh:
     params:
         threshold=lambda wildcards: surf_thresholds[wildcards.surfname],
         decimate_opts={
-            "reduction": 0.1,
+            "reduction": 0.2,
             "preserve_topology": True,
             "boundary_vertex_deletion": False,
-        },  #0.3 reduction seems to solve resampling memory issue
+        },
         clean_method="cleanAK",  #cleanAK or cleanJD 
         morph_openclose_dist=2,  # mm
         coords_epsilon=0.1,

--- a/hippunfold/workflow/rules/native_surf.smk
+++ b/hippunfold/workflow/rules/native_surf.smk
@@ -70,7 +70,7 @@ rule gen_native_mesh:
             "feature_angle": 25,
             "preserve_topology": True,
         },
-        hole_fill_radius=0.1,
+        hole_fill_radius=1.0,
         clean_method="cleanAK",  #cleanAK or cleanJD 
         morph_openclose_dist=2,  # mm
         coords_epsilon=0.1,

--- a/hippunfold/workflow/scripts/gen_isosurface.py
+++ b/hippunfold/workflow/scripts/gen_isosurface.py
@@ -119,9 +119,17 @@ surface = tfm_grid.contour(
 )
 logger.info(surface)
 
+# remove the nan-valued vertices - this isn't handled in PolyData.clean()
+logger.info("Removing nan-valued vertices")
+surface = remove_nan_vertices(surface)
+logger.info(surface)
 
 logger.info("Cleaning surface")
 surface = surface.clean(point_merging=False)
+logger.info(surface)
+
+logger.info("Extracting largest connected component")
+surface = surface.extract_largest()
 logger.info(surface)
 
 """
@@ -136,12 +144,12 @@ surface = surface.smooth_taubin(#normalize_coordinates=True,
 logger.info(surface)
 """
 
-logger.info("Filling holes up to radius {snakemake.params.hole_fill_radius}")
+logger.info(f"Filling holes up to radius {snakemake.params.hole_fill_radius}")
 surface = surface.fill_holes(snakemake.params.hole_fill_radius)
 logger.info(surface)
 
 # reduce # of vertices with decimation
-logger.info("Decimating surface")
+logger.info(f"Decimating surface with {snakemake.params.decimate_opts}")
 surface = surface.decimate_pro(**snakemake.params.decimate_opts)
 logger.info(surface)
 
@@ -180,10 +188,6 @@ if snakemake.params.clean_method == "cleanJD":
     surface.points[bad_v, :] = np.nan
     surface = remove_nan_vertices(surface)
 
-# Extract the largest connected component
-logger.info("Extracting largest connected component")
-surface = surface.extract_largest()
-logger.info(surface)
 
 # Save the final mesh
 write_surface_to_gifti(surface, snakemake.output.surf_gii)

--- a/hippunfold/workflow/scripts/gen_isosurface.py
+++ b/hippunfold/workflow/scripts/gen_isosurface.py
@@ -170,9 +170,9 @@ if snakemake.params.clean_method == "cleanJD":
 
     # this is equivalent to wb_command -volume-to-surface-mapping -enclosing
     # apply inverse affine to surface to get back to matrix space
-    surface = apply_affine_transform(surface, affine, inverse=True)
+    xfm_surface = apply_affine_transform(surface, affine, inverse=True)
 
-    V = np.round(surface.points).astype("int") - 1
+    V = np.round(xfm_surface.points).astype("int") - 1
     # sample coords
     coord_at_V = coords[V[:, 0], V[:, 1], V[:, 2]]
 

--- a/hippunfold/workflow/scripts/gen_isosurface.py
+++ b/hippunfold/workflow/scripts/gen_isosurface.py
@@ -208,13 +208,14 @@ if snakemake.params.clean_method == "cleanJD":
     points[bad_v, :] = np.nan
     points, faces = remove_nan_vertices(points, faces)
 
-    # apply largest connected component
-    faces_pv = np.hstack([np.full((faces.shape[0], 1), 3), faces])
-    mesh = pv.PolyData(points, faces_pv)
-    mesh_cc = mesh.extract_largest()
-    points = mesh_cc.points  # This gives you the vertices
-    faces = mesh_cc.faces
-    faces = faces.reshape((int(faces.shape[0] / 4), 4))[:, 1:4]
+
+# apply largest connected component
+faces_pv = np.hstack([np.full((faces.shape[0], 1), 3), faces])
+mesh = pv.PolyData(points, faces_pv)
+mesh_cc = mesh.extract_largest()
+points = mesh_cc.points  # This gives you the vertices
+faces = mesh_cc.faces
+faces = faces.reshape((int(faces.shape[0] / 4), 4))[:, 1:4]
 
 
 # write to gifti

--- a/hippunfold/workflow/scripts/gen_isosurface.py
+++ b/hippunfold/workflow/scripts/gen_isosurface.py
@@ -161,6 +161,12 @@ tfm_grid = grid.transform(
 
 # the contour function produces the isosurface
 surface = tfm_grid.contour([snakemake.params.threshold], method="contour")
+if snakemake.params.decimation_target
+    faces = surface.faces
+    faces = faces.reshape((int(faces.shape[0] / 4), 4))[:, 1:4]
+    points = surface.points
+    edge_lengths = np.linalg.norm(points[faces[:, 0]] - points[faces[:, 1]], axis=1)
+    snakemake.params.decimate_opts["reduction"] = (snakemake.params.decimation_target / np.mean(edge_lengths))**2
 surface = surface.decimate_pro(**snakemake.params.decimate_opts)
 
 # faces from pyvista surface are formatted with number of verts each row

--- a/hippunfold/workflow/scripts/gen_isosurface.py
+++ b/hippunfold/workflow/scripts/gen_isosurface.py
@@ -161,12 +161,14 @@ tfm_grid = grid.transform(
 
 # the contour function produces the isosurface
 surface = tfm_grid.contour([snakemake.params.threshold], method="contour")
-if snakemake.params.decimation_target
+if snakemake.params.decimation_target:
     faces = surface.faces
     faces = faces.reshape((int(faces.shape[0] / 4), 4))[:, 1:4]
     points = surface.points
     edge_lengths = np.linalg.norm(points[faces[:, 0]] - points[faces[:, 1]], axis=1)
-    snakemake.params.decimate_opts["reduction"] = (snakemake.params.decimation_target / np.mean(edge_lengths))**2
+    snakemake.params.decimate_opts["reduction"] = (
+        snakemake.params.decimation_target / np.mean(edge_lengths)
+    ) ** 2
 surface = surface.decimate_pro(**snakemake.params.decimate_opts)
 
 # faces from pyvista surface are formatted with number of verts each row

--- a/hippunfold/workflow/scripts/gen_isosurface.py
+++ b/hippunfold/workflow/scripts/gen_isosurface.py
@@ -192,11 +192,7 @@ if snakemake.params.clean_method == "cleanJD":
     V = apply_affine_transform(points, affine, inverse=True)
     V = V.astype(int)
     # sample coords
-    coord_at_V = np.zeros((len(V)))
-    for i in range(len(V)):
-        coord_at_V[i] = coords[
-            V[i, 0], V[i, 1], V[i, 2]
-        ]  # really hope there's no x-y switching fuckery here!
+    coord_at_V = coords[V[:, 0], V[:, 1], V[:, 2]]
 
     # keep vertices that are in a nice coordinate range
     epsilon = snakemake.params.coords_epsilon


### PR DESCRIPTION
- for clean_method, cleanAK and cleanJD can be specified, but in my hippocampal test case, they are indistinguishable..
- decimation is also enabled by default to fix memory issues with surface resampling (even just a little decimation seems to solve it)
- note: decimation only works with cleanAK (cleanJD seems to choke on decimated surfaces)..