### PR TITLE
orthogonalize AP/PD srs/cink edges

### DIFF
--- a/hippunfold/workflow/scripts/get_boundary_vertices.py
+++ b/hippunfold/workflow/scripts/get_boundary_vertices.py
@@ -67,6 +67,16 @@ logger.info(
     f"Boundary scalar array created. {np.sum(boundary_scalars)} boundary vertices marked."
 )
 
+# Find the largest connected component within this sub-mesh
+sub_mesh = pv.PolyData(surface.points, surface.faces).extract_points(
+    boundary_scalars.astype(bool), adjacent_cells=True
+)
+largest_component_indices = sub_mesh.connectivity(largest=True).point_data["RegionId"]
+boundary_scalars = np.zeros(surface.n_points, dtype=int)
+boundary_scalars[largest_component.point_data["vtkOriginalPointIds"]] = 1
+logger.info("Applying largest connected components")
+
+
 logger.info("Saving GIFTI label file...")
 
 # Create a GIFTI label data array

--- a/hippunfold/workflow/scripts/postproc_boundary_vertices.py
+++ b/hippunfold/workflow/scripts/postproc_boundary_vertices.py
@@ -1,0 +1,61 @@
+import pyvista as pv
+import numpy as np
+import nibabel as nib
+import nibabel.gifti as gifti
+from collections import Counter
+from scipy.signal import argrelextrema
+
+nmin = snakemake.params.min_terminal_vertices
+
+logger.info("Loading surface from GIFTI...")
+edges = nib.load(snakemake.input.edges).agg_data()
+ap_src = nib.load(snakemake.input.ap_src).agg_data()
+ap_sink = nib.load(snakemake.input.ap_sink).agg_data()
+pd_src = nib.load(snakemake.input.pd_src).agg_data()
+pd_sink = nib.load(snakemake.input.pd_sink).agg_data()
+
+distances = np.vstack(
+    (ap_src[edges == 1], ap_sink[edges == 1], pd_src[edges == 1], pd_sink[edges == 1])
+)
+num_vertices = distances.shape[0]
+
+
+logger.info("Assigning labels apsrc, apsink, pdsrc, pdsink")
+
+max_iterations = 10  # Prevent infinite loops
+for _ in range(max_iterations):
+    # Scale distances
+    scaled_distances = distances * scaling_factors
+
+    # Assign labels based on min scaled distance
+    labels = np.argmin(scaled_distances, axis=1)
+
+    # Count occurrences per label
+    unique, counts = np.unique(labels, return_counts=True)
+    label_counts = {
+        k: counts[i] if k in unique else 0 for i, k in enumerate(range(num_labels))
+    }
+
+    # Check if all labels meet nmin
+    if all(count >= nmin for count in label_counts.values()):
+        break  # Stop if all labels are sufficiently represented
+
+    # Update scaling factors for underrepresented labels
+    for k in range(num_labels):
+        if label_counts[k] < nmin:
+            scaling_factors[k] *= 1.5  # Increase competitiveness of the label
+
+# Ensure all labels are represented
+logger.info("Final label counts:", label_counts)
+
+ap_srcsink = np.zeros((len(edges)))
+ap_srcsink[edges == 1][labels == 0] = 1
+ap_srcsink[edges == 1][labels == 1] = 2
+gii_img = gifti.GiftiImage(darrays=[ap_srcsink])
+nib.save(gii_img, snakemake.outputs.ap)
+
+pd_srcsink = np.zeros((len(edges)))
+pd_srcsink[edges == 1][labels == 2] = 1
+pd_srcsink[edges == 1][labels == 3] = 2
+gii_img = gifti.GiftiImage(darrays=[pd_srcsink])
+nib.save(gii_img, snakemake.outputs.pd)


### PR DESCRIPTION
This approach continues with the distance transform logic introduced by https://github.com/khanlab/hippunfold/pull/371, and closes https://github.com/khanlab/hippunfold/issues/373. 

We want to ensure that all edge vertices are assigned to an AP or PD source or sink (4 possible labels), without overlapping or missing any vertices (I will call this orthogonal edge conditions). Otherwise we can end up with "corners" that are entire missing from the unfolded space, or other funny distortions in the unfolding. 

Here, we introduce a new script to fix this up:

- we move the application of signed distance transforms out of the laplace-beltrami solver rule and into its own rule, where we jointly solve AP and PD edges
- instead of iteratively increasing distances to add vertices, we treat the distances as probabilities for one of these 4 labels and take the maxprob
- in some cases we will still not have min_terminal_vertices>5. In these cases, we gradually increase the distance scaling factor from that label until min_terminal_vertices is reached. 
- we get to keep parallelization of laplace-betrami. AP and PD edges do have to be processed jointly though, to ensure they are orthogonal. We also get to toss out a bunch of complicated functions

we also now apply largest connected component to finding boundary vertices to prevent issues with holes

TODO: 
- we could still ensure conncomp in addition to min_terminal_vertices, but i don't think its necessary
- parameter to adjust distance scaling factor stepsize?