### PR TITLE
Enable the use of containers when --use-conda is not defined

### DIFF
--- a/hippunfold/workflow/rules/common.smk
+++ b/hippunfold/workflow/rules/common.smk
@@ -1,7 +1,24 @@
 from appdirs import AppDirs
 from snakebids.paths import bids_factory, specs
-
 from functools import partial
+
+
+def conda_env(env_name):
+    """
+    Returns the path to the Conda environment file if --use-conda is set, otherwise returns None.
+
+    Args:
+        env_name (str): The name of the environment.
+
+    Returns:
+        str or None: Path to the Conda YAML file or None.
+    """
+
+    from snakemake.settings.types import DeploymentMethod
+
+    if DeploymentMethod.CONDA in workflow.deployment_settings.deployment_method:
+        return f"../envs/{env_name}.yaml"
+    return None
 
 
 def get_single_bids_input(wildcards, component):

--- a/hippunfold/workflow/rules/common.smk
+++ b/hippunfold/workflow/rules/common.smk
@@ -13,11 +13,23 @@ def conda_env(env_name):
     Returns:
         str or None: Path to the Conda YAML file or None.
     """
+    import snakemake
+    from packaging.version import parse
 
-    from snakemake.settings.types import DeploymentMethod
+    # Get Snakemake version
+    snakemake_version = parse(snakemake.__version__)
 
-    if DeploymentMethod.CONDA in workflow.deployment_settings.deployment_method:
-        return f"../envs/{env_name}.yaml"
+    if snakemake_version >= parse("8.0.0"):
+        # Snakemake >= 8.0
+        from snakemake.settings.types import DeploymentMethod
+
+        if DeploymentMethod.CONDA in workflow.deployment_settings.deployment_method:
+            return f"../envs/{env_name}.yaml"
+    else:
+        # Snakemake < 8.0
+        if workflow.use_conda:
+            return f"../envs/{env_name}.yaml"
+
     return None
 
 

--- a/hippunfold/workflow/rules/coords.smk
+++ b/hippunfold/workflow/rules/coords.smk
@@ -71,7 +71,7 @@ rule get_label_mask:
     group:
         "subj"
     conda:
-        "../envs/c3d.yaml"
+        conda_env("c3d")
     shell:
         "c3d {input} -background -1 -retain-labels {params} -binarize {output}"
 
@@ -116,7 +116,7 @@ rule get_src_sink_mask:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/c3d.yaml"
+        conda_env("c3d")
     group:
         "subj"
     shell:
@@ -152,7 +152,7 @@ rule get_src_sink_sdt:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/c3d.yaml"
+        conda_env("c3d")
     group:
         "subj"
     shell:
@@ -179,7 +179,7 @@ rule get_nan_mask:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/c3d.yaml"
+        conda_env("c3d")
     group:
         "subj"
     shell:
@@ -207,7 +207,7 @@ rule create_upsampled_coords_ref:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/c3d.yaml"
+        conda_env("c3d")
     group:
         "subj"
     container:
@@ -259,7 +259,7 @@ rule prep_dseg_for_laynii:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/c3d.yaml"
+        conda_env("c3d")
     group:
         "subj"
     shell:
@@ -296,7 +296,7 @@ rule laynii_layers_equidist:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/laynii.yaml"
+        conda_env("laynii")
     group:
         "subj"
     shell:
@@ -335,7 +335,7 @@ rule laynii_layers_equivol:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/laynii.yaml"
+        conda_env("laynii")
     group:
         "subj"
     shell:

--- a/hippunfold/workflow/rules/download.smk
+++ b/hippunfold/workflow/rules/download.smk
@@ -82,7 +82,7 @@ rule import_template_dseg:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/c3d.yaml"
+        conda_env("c3d")
     shell:
         "{params.copy_or_flip_cmd} {output.template_seg}"
 
@@ -121,7 +121,7 @@ rule import_template_dseg_dentate:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/c3d.yaml"
+        conda_env("c3d")
     shell:
         "{params.copy_or_flip_cmd} {output.template_seg}"
 
@@ -162,7 +162,7 @@ rule import_template_coords:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/c3d.yaml"
+        conda_env("c3d")
     shell:
         "{params.copy_or_flip_cmd} {output.template_coords}"
 
@@ -202,6 +202,6 @@ rule import_template_anat:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/c3d.yaml"
+        conda_env("c3d")
     shell:
         "{params.copy_or_flip_cmd} {output.template_anat}"

--- a/hippunfold/workflow/rules/gifti.smk
+++ b/hippunfold/workflow/rules/gifti.smk
@@ -47,7 +47,7 @@ rule cp_template_to_unfold:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     group:
         "subj"
     shell:
@@ -88,7 +88,7 @@ rule calc_unfold_template_coords:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     shadow:
         "minimal"  #this is required to use the temporary files defined as params
     group:
@@ -143,7 +143,7 @@ rule affine_gii_to_native:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/ants.yaml"
+        conda_env("ants")
     group:
         "subj"
     shell:
@@ -208,7 +208,7 @@ rule create_dscalar_metric_cifti:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     group:
         "subj"
     shell:
@@ -276,7 +276,7 @@ rule create_dlabel_cifti_subfields:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     group:
         "subj"
     shell:
@@ -386,7 +386,7 @@ rule create_spec_file_hipp:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     group:
         "subj"
     shell:
@@ -453,7 +453,7 @@ rule create_spec_file_dentate:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     group:
         "subj"
     shell:
@@ -498,7 +498,7 @@ rule merge_lr_spec_file_native:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     group:
         "subj"
     shell:
@@ -534,7 +534,7 @@ rule merge_hipp_dentate_spec_file_native:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     group:
         "subj"
     shell:

--- a/hippunfold/workflow/rules/myelin_map.smk
+++ b/hippunfold/workflow/rules/myelin_map.smk
@@ -34,7 +34,7 @@ rule divide_t1_by_t2:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/c3d.yaml"
+        conda_env("c3d")
     shell:
         "c3d {input.t1} {input.t2} -divide -replace inf 1000 -inf -1000 NaN 0 -o {output}"
 
@@ -94,6 +94,6 @@ rule sample_myelin_map_surf:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     shell:
         "wb_command -volume-to-surface-mapping {input.vol} {input.mid} {output.metric} -ribbon-constrained {input.outer} {input.inner}"

--- a/hippunfold/workflow/rules/native_surf.smk
+++ b/hippunfold/workflow/rules/native_surf.smk
@@ -93,7 +93,7 @@ rule gen_native_mesh:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/pyvista.yaml"
+        conda_env("pyvista")
     script:
         "../scripts/gen_isosurface.py"
 
@@ -127,7 +127,7 @@ rule update_native_mesh_structure:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     group:
         "subj"
     shell:
@@ -164,7 +164,7 @@ rule smooth_surface:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     group:
         "subj"
     shell:
@@ -200,7 +200,7 @@ rule get_boundary_vertices:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/pyvista.yaml"
+        conda_env("pyvista")
     script:
         "../scripts/get_boundary_vertices.py"
 
@@ -243,7 +243,7 @@ rule map_src_sink_sdt_to_surf:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     group:
         "subj"
     shell:
@@ -345,7 +345,7 @@ rule postproc_boundary_vertices:
             **inputs.subj_wildcards,
         ),
     conda:
-        "../envs/pyvista.yaml"
+        conda_env("pyvista")
     group:
         "subj"
     script:
@@ -401,7 +401,7 @@ rule laplace_beltrami:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/pyvista.yaml"
+        conda_env("pyvista")
     script:
         "../scripts/laplace_beltrami.py"
 
@@ -460,7 +460,7 @@ rule warp_native_mesh_to_unfold:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/pyunfold.yaml"
+        conda_env("pyunfold")
     group:
         "subj"
     script:
@@ -495,7 +495,7 @@ rule update_unfold_mesh_structure:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     group:
         "subj"
     shell:
@@ -536,7 +536,7 @@ rule heavy_smooth_unfold_surf:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     group:
         "subj"
     shell:
@@ -592,7 +592,7 @@ rule compute_halfthick_mask:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/c3d.yaml"
+        conda_env("c3d")
     shell:
         "c3d {input.coords} -threshold {params.threshold_tofrom} 1 0 {input.mask} -multiply -o {output}"
 
@@ -640,7 +640,7 @@ rule register_midthickness:
         config["singularity"]["autotop"]
     threads: 16
     conda:
-        "../envs/greedy.yaml"
+        conda_env("greedy")
     shell:
         "greedy -threads {threads} -d 3 -i {input.fixed} {input.moving} -n 30x0 -o {output.warp}"
 
@@ -698,7 +698,7 @@ rule apply_halfsurf_warp_to_img:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/greedy.yaml"
+        conda_env("greedy")
     shell:
         "greedy -d 3  -rf {input.fixed} -rm {input.moving} {output.warped}  -r {input.warp} "
 
@@ -736,7 +736,7 @@ rule convert_inout_warp_from_itk_to_world:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     shell:
         "wb_command -convert-warpfield -from-itk {input} -to-world {output}"
 
@@ -780,7 +780,7 @@ rule warp_midthickness_to_inout:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     shadow:
         "minimal"
     group:
@@ -830,7 +830,7 @@ rule affine_gii_corobl_to_modality:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     group:
         "subj"
     shell:
@@ -864,7 +864,7 @@ rule calculate_surface_area:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     group:
         "subj"
     shell:
@@ -906,7 +906,7 @@ rule calculate_legacy_gyrification:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     group:
         "subj"
     shell:
@@ -939,7 +939,7 @@ rule calculate_curvature:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     group:
         "subj"
     shell:
@@ -979,7 +979,7 @@ rule calculate_thickness:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     group:
         "subj"
     shell:
@@ -1024,7 +1024,7 @@ rule pad_unfold_ref:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/c3d.yaml"
+        conda_env("c3d")
     group:
         "subj"
     shell:
@@ -1058,7 +1058,7 @@ rule extract_unfold_ref_slice:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/c3d.yaml"
+        conda_env("c3d")
     group:
         "subj"
     shell:
@@ -1129,7 +1129,7 @@ rule native_metric_to_unfold_nii:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     group:
         "subj"
     shell:
@@ -1181,7 +1181,7 @@ rule atlas_metric_to_unfold_nii:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     group:
         "subj"
     shell:
@@ -1282,7 +1282,7 @@ rule unfoldreg_antsquick:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/ants.yaml"
+        conda_env("ants")
     group:
         "subj"
     log:
@@ -1339,7 +1339,7 @@ rule unfoldreg_greedy:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/greedy.yaml"
+        conda_env("greedy")
     group:
         "subj"
     log:
@@ -1410,7 +1410,7 @@ rule extend_warp_2d_to_3d:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/neurovis.yaml"
+        conda_env("neurovis")
     group:
         "subj"
     script:
@@ -1451,7 +1451,7 @@ rule convert_unfoldreg_warp_from_itk_to_world:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     shell:
         "wb_command -convert-warpfield -from-itk {input} -to-world {output}"
 
@@ -1518,7 +1518,7 @@ rule warp_unfold_native_to_unfoldreg:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     group:
         "subj"
     shadow:
@@ -1565,7 +1565,7 @@ rule resample_atlas_subfields_to_std_density:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     group:
         "subj"
     shell:
@@ -1605,7 +1605,7 @@ rule resample_native_surf_to_std_density:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     group:
         "subj"
     shell:
@@ -1645,7 +1645,7 @@ rule resample_native_metric_to_std_density:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     group:
         "subj"
     shell:
@@ -1707,7 +1707,7 @@ rule resample_atlas_subfields_to_native_surf:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     group:
         "subj"
     shell:
@@ -1760,7 +1760,7 @@ rule atlas_label_to_unfold_nii:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     group:
         "subj"
     shell:
@@ -1817,7 +1817,7 @@ rule create_dscalar_metric_cifti_native:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     group:
         "subj"
     shell:
@@ -1873,7 +1873,7 @@ rule create_dlabel_cifti_subfields_native:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     group:
         "subj"
     shell:
@@ -1966,7 +1966,7 @@ rule create_spec_file_hipp_native:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     group:
         "subj"
     shell:
@@ -2029,7 +2029,7 @@ rule create_spec_file_dentate_native:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     group:
         "subj"
     shell:
@@ -2065,7 +2065,7 @@ rule merge_lr_spec_file:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     group:
         "subj"
     shell:
@@ -2099,7 +2099,7 @@ rule merge_hipp_dentate_spec_file:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     group:
         "subj"
     shell:

--- a/hippunfold/workflow/rules/nnunet.smk
+++ b/hippunfold/workflow/rules/nnunet.smk
@@ -157,7 +157,7 @@ rule run_inference:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/nnunet.yaml"
+        conda_env("nnunet")
     shell:
         #create temp folders
         #cp input image to temp folder
@@ -245,7 +245,7 @@ rule qc_nnunet_f3d:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/niftyreg.yaml"
+        conda_env("niftyreg")
     log:
         bids(
             root="logs",
@@ -300,6 +300,6 @@ rule qc_nnunet_dice:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/pyunfold.yaml"
+        conda_env("pyunfold")
     script:
         "../scripts/dice.py"

--- a/hippunfold/workflow/rules/preproc_dsegtissue.smk
+++ b/hippunfold/workflow/rules/preproc_dsegtissue.smk
@@ -21,7 +21,7 @@ rule import_dseg_tissue:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/c3d.yaml"
+        conda_env("c3d")
     group:
         "subj"
     shell:

--- a/hippunfold/workflow/rules/preproc_hippb500.smk
+++ b/hippunfold/workflow/rules/preproc_hippb500.smk
@@ -24,7 +24,7 @@ rule resample_hippdwi_to_template:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/c3d.yaml"
+        conda_env("c3d")
     group:
         "subj"
     shell:

--- a/hippunfold/workflow/rules/preproc_t1.smk
+++ b/hippunfold/workflow/rules/preproc_t1.smk
@@ -52,7 +52,7 @@ else:
         container:
             config["singularity"]["autotop"]
         conda:
-            "../envs/ants.yaml"
+            conda_env("ants")
         group:
             "subj"
         shell:
@@ -99,7 +99,7 @@ rule warp_t1_to_corobl_crop:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/ants.yaml"
+        conda_env("ants")
     group:
         "subj"
     shell:

--- a/hippunfold/workflow/rules/preproc_t2.smk
+++ b/hippunfold/workflow/rules/preproc_t2.smk
@@ -34,7 +34,7 @@ rule n4_t2:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/ants.yaml"
+        conda_env("ants")
     group:
         "subj"
     shell:
@@ -104,7 +104,7 @@ rule reg_t2_to_ref:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/niftyreg.yaml"
+        conda_env("niftyreg")
     group:
         "subj"
     shell:
@@ -137,7 +137,7 @@ rule ras_to_itk_reg_t2:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/c3d.yaml"
+        conda_env("c3d")
     group:
         "subj"
     shell:
@@ -206,7 +206,7 @@ else:
         container:
             config["singularity"]["autotop"]
         conda:
-            "../envs/c3d.yaml"
+            conda_env("c3d")
         group:
             "subj"
         shell:
@@ -261,7 +261,7 @@ rule reg_t2_to_t1_part1:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/niftyreg.yaml"
+        conda_env("niftyreg")
     group:
         "subj"
     shell:
@@ -294,7 +294,7 @@ rule reg_t2_to_t1_part2:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/c3d.yaml"
+        conda_env("c3d")
     group:
         "subj"
     shell:
@@ -398,7 +398,7 @@ rule compose_t2_xfm_corobl:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/c3d.yaml"
+        conda_env("c3d")
     group:
         "subj"
     shell:
@@ -462,7 +462,7 @@ rule warp_t2_to_corobl_crop:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/ants.yaml"
+        conda_env("ants")
     group:
         "subj"
     shell:

--- a/hippunfold/workflow/rules/qc.smk
+++ b/hippunfold/workflow/rules/qc.smk
@@ -34,7 +34,7 @@ rule qc_reg_to_template:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/neurovis.yaml"
+        conda_env("neurovis")
     script:
         "../scripts/vis_regqc.py"
 
@@ -76,7 +76,7 @@ rule get_subfield_vols_subj:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/pyunfold.yaml"
+        conda_env("pyunfold")
     script:
         "../scripts/gen_volume_tsv.py"
 
@@ -111,7 +111,7 @@ rule plot_subj_subfields:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/neurovis.yaml"
+        conda_env("neurovis")
     script:
         "../scripts/plot_subj_subfields.py"
 
@@ -197,7 +197,7 @@ rule qc_subfield:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/neurovis.yaml"
+        conda_env("neurovis")
     script:
         "../scripts/vis_qc_dseg.py"
 
@@ -235,7 +235,7 @@ rule qc_subfield_surf:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/neurovis.yaml"
+        conda_env("neurovis")
     script:
         "../scripts/vis_qc_surf.py"
 
@@ -273,6 +273,6 @@ rule concat_subj_vols_tsv:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/neurovis.yaml"
+        conda_env("neurovis")
     script:
         "../scripts/concat_tsv.py"

--- a/hippunfold/workflow/rules/resample_final_to_crop_native.smk
+++ b/hippunfold/workflow/rules/resample_final_to_crop_native.smk
@@ -32,7 +32,7 @@ rule create_native_crop_ref:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/c3d.yaml"
+        conda_env("c3d")
     group:
         "subj"
     shell:
@@ -81,7 +81,7 @@ rule resample_unet_native_crop:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/ants.yaml"
+        conda_env("ants")
     group:
         "subj"
     shell:
@@ -132,7 +132,7 @@ rule resample_postproc_native_crop:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/ants.yaml"
+        conda_env("ants")
     group:
         "subj"
     shell:
@@ -186,7 +186,7 @@ rule resample_subfields_native_crop:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/ants.yaml"
+        conda_env("ants")
     group:
         "subj"
     shell:
@@ -240,7 +240,7 @@ rule resample_coords_native_crop:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/ants.yaml"
+        conda_env("ants")
     group:
         "subj"
     shell:
@@ -278,7 +278,7 @@ rule resample_native_to_crop:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/ants.yaml"
+        conda_env("ants")
     group:
         "subj"
     shell:
@@ -338,7 +338,7 @@ rule resample_t2_to_crop:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/ants.yaml"
+        conda_env("ants")
     group:
         "subj"
     shell:

--- a/hippunfold/workflow/rules/shape_inject.smk
+++ b/hippunfold/workflow/rules/shape_inject.smk
@@ -38,7 +38,7 @@ rule prep_segs_for_greedy:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/c3d.yaml"
+        conda_env("c3d")
     shell:
         "mkdir -p {output} && "
         "c3d {input} -retain-labels {params.labels} -split -foreach -smooth {params.smoothing_stdev} -endfor -oo {output}/label_%02d.nii.gz"
@@ -118,7 +118,7 @@ rule resample_template_dseg_tissue_for_reg:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/c3d.yaml"
+        conda_env("c3d")
     group:
         "subj"
     shell:
@@ -171,7 +171,7 @@ rule template_shape_reg:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/greedy.yaml"
+        conda_env("greedy")
     threads: 8
     log:
         bids(
@@ -220,7 +220,7 @@ rule dilate_dentate_pd_src_sink:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/neurovis.yaml"
+        conda_env("neurovis")
     script:
         "../scripts/dilate_dentate_pd_src_sink.py"
 
@@ -295,7 +295,7 @@ rule template_shape_inject:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/greedy.yaml"
+        conda_env("greedy")
     threads: 8
     shell:
         "greedy -d 3 -threads {threads} {params.interp_opt} -rf {input.upsampled_ref} -rm {input.template_seg} {output.inject_seg}  -r {input.warp} {input.matrix} &> {log}"
@@ -377,7 +377,7 @@ rule inject_init_laplace_coords:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/greedy.yaml"
+        conda_env("greedy")
     threads: 8
     shell:
         "greedy -d 3 -threads {threads} {params.interp_opt} -rf {input.upsampled_ref} -rm {input.coords} {output.init_coords}  -r {input.warp} {input.matrix} &> {log}"
@@ -421,7 +421,7 @@ rule reinsert_subject_labels:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/c3d.yaml"
+        conda_env("c3d")
     shell:
         "c3d {input.subject_seg} -retain-labels {params.labels} -popas LBL "
         " -int 0 {input.inject_seg} -as SEG -push LBL -reslice-identity -popas LBL_RESLICE "

--- a/hippunfold/workflow/rules/subfields.smk
+++ b/hippunfold/workflow/rules/subfields.smk
@@ -16,7 +16,7 @@ rule import_dseg_subfields:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     group:
         "subj"
     shell:
@@ -54,7 +54,7 @@ rule subfields_to_label_gifti:
             **inputs.subj_wildcards,
         ),
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     container:
         config["singularity"]["autotop"]
     shell:
@@ -117,7 +117,7 @@ rule label_subfields_from_vol_coords_corobl:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/workbench.yaml"
+        conda_env("workbench")
     group:
         "subj"
     shell:
@@ -177,7 +177,7 @@ rule combine_tissue_subfield_labels_corobl:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/c3d.yaml"
+        conda_env("c3d")
     group:
         "subj"
     shell:
@@ -230,7 +230,7 @@ rule resample_subfields_to_native:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/ants.yaml"
+        conda_env("ants")
     group:
         "subj"
     shell:
@@ -281,7 +281,7 @@ rule resample_postproc_to_native:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/ants.yaml"
+        conda_env("ants")
     group:
         "subj"
     shell:
@@ -331,7 +331,7 @@ rule resample_unet_to_native:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/ants.yaml"
+        conda_env("ants")
     group:
         "subj"
     shell:
@@ -376,7 +376,7 @@ rule resample_subfields_to_unfold:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/ants.yaml"
+        conda_env("ants")
     group:
         "subj"
     shell:

--- a/hippunfold/workflow/rules/templateseg.smk
+++ b/hippunfold/workflow/rules/templateseg.smk
@@ -56,7 +56,7 @@ rule template_reg:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/greedy.yaml"
+        conda_env("greedy")
     threads: 8
     shell:
         "greedy -threads {threads} {params.general_opts} "
@@ -114,7 +114,7 @@ rule warp_template_dseg:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/greedy.yaml"
+        conda_env("greedy")
     threads: 8
     shell:
         "greedy -d 3 -threads {threads} {params.interp_opt} -rf {input.ref} -rm {input.template_dseg} {output.inject_seg}  -r {input.warp}"
@@ -173,7 +173,7 @@ rule warp_template_coords:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/greedy.yaml"
+        conda_env("greedy")
     threads: 8
     shell:
         "greedy -d 3 -threads {threads} {params.interp_opt} -rf {input.ref} -rm {input.template_coords} {output.init_coords}  -r {input.warp}"
@@ -231,7 +231,7 @@ rule warp_template_anat:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/greedy.yaml"
+        conda_env("greedy")
     threads: 8
     shell:
         "greedy -d 3 -threads {threads} -rf {input.ref} -rm {params.template_anat} {output.warped}  -r  {input.warp} {params.xfm_corobl}"

--- a/hippunfold/workflow/rules/warps.smk
+++ b/hippunfold/workflow/rules/warps.smk
@@ -60,7 +60,7 @@ rule reg_to_template:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/niftyreg.yaml"
+        conda_env("niftyreg")
     group:
         "subj"
     shell:
@@ -93,7 +93,7 @@ rule convert_template_xfm_ras2itk:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/c3d.yaml"
+        conda_env("c3d")
     group:
         "subj"
     shell:
@@ -133,7 +133,7 @@ rule compose_template_xfm_corobl:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/c3d.yaml"
+        conda_env("c3d")
     group:
         "subj"
     shell:
@@ -166,7 +166,7 @@ rule invert_template_xfm_itk2ras:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/c3d.yaml"
+        conda_env("c3d")
     group:
         "subj"
     shell:
@@ -199,7 +199,7 @@ rule template_xfm_itk2ras:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/c3d.yaml"
+        conda_env("c3d")
     group:
         "subj"
     shell:
@@ -233,6 +233,6 @@ rule create_unfold_ref:
     container:
         config["singularity"]["autotop"]
     conda:
-        "../envs/c3d.yaml"
+        conda_env("c3d")
     shell:
         "c3d -create {params.dims} {params.voxdims}mm -origin {params.origin}mm -orient {params.orient} -o {output.nii}"


### PR DESCRIPTION
The issue was that whenever any rule has both a conda and container directive defined, then it checks the version of conda in the container, since the behaviour will be to use the container to build the conda env. 

But for us, we just want the container to be used without conda at all, so this adds a wrapper when defining conda environments, so that it is set to `None` if the `--use-conda` flag is not set. 

Looks to be working fine in dry-run, will do a full test now.. 