### PR TITLE
Fix nnunet conda env

### DIFF
--- a/hippunfold/workflow/envs/nnunet.yaml
+++ b/hippunfold/workflow/envs/nnunet.yaml
@@ -1,7 +1,8 @@
 name: nnunet
 channels:
+  - khanlab
   - conda-forge
   - defaults
 dependencies:
   - python=3.9
-  - nnunet=1.7.1
+  - nnunet-inference-on-cpu-and-gpu=1.6.6


### PR DESCRIPTION
This PR resolves issue #380. To achieve this, I put a custom `nnunet` conda package, i.e., `nnunet-inference-on-cpu-and-gpu=1.6.6` on our khanlab channel and pull from it for creating conda env while running `hippunfold`. The issue was stemming from the version of pytorch used in building nnunet's conda package and after pinning it to `v1.10.0` in its recipe, I was successfully able to get past the `run_inference` rule. I just ran the pipeline with `--untill run_inference` but ideally I'd like to run an entire end to end session before we merge. 