### PR TITLE
increase padding for upsampled ref space

### DIFF
--- a/hippunfold/run_quick.py
+++ b/hippunfold/run_quick.py
@@ -1,92 +1,89 @@
-from argparse import ArgumentParser
 import os
-import tempfile
 import shutil
 import subprocess
+import tempfile
+from argparse import ArgumentParser
+
 
 def gen_parser():
     parser = ArgumentParser(description="Run hippunfold for a single subject.")
 
     # command line arguments for hippunfold-quick
     parser.add_argument(
-        "--input", 
-        required=True, 
-        help="File path to your input NIfTI image."
+        "--input", required=True, help="File path to your input NIfTI image."
     )
     parser.add_argument(
-        "--output", 
-        required=True, 
-        help="Path to your desired output folder."
+        "--output", required=True, help="Path to your desired output folder."
+    )
+    parser.add_argument("--subject", required=True, help="Subject ID (e.g., 001).")
+    parser.add_argument(
+        "--modality",
+        required=True,
+        choices=["T1w", "T2w", "hippb500", "dsegtissue"],
+        help="Image modality.",
     )
     parser.add_argument(
-        "--subject", 
-        required=True, 
-        help="Subject ID (e.g., 001)."
-    )
-    parser.add_argument(
-        "--modality", 
-        required=True, 
-        choices=["T1w", "T2w", "hippb500", "dsegtissue"], 
-        help="Image modality."
-    )
-    parser.add_argument(
-        "--temp-dir", 
-        default=None, 
-        help="Optional temporary directory. If not specified, a system temp directory will be used."
+        "--temp-dir",
+        default=None,
+        help="Optional temporary directory. If not specified, a system temp directory will be used.",
     )
     parser.add_argument(
         "--use-singularity",
         action="store_true",
         help="If specified, will run hippunfold using Singularity. "
-            "This requires Singularity to be installed on your system."
+        "This requires Singularity to be installed on your system.",
     )
     parser.add_argument(
         "--use-conda",
         action="store_true",
         help="If specified, will run hippunfold using Conda environments. "
-            "This requires Conda to be installed on your system."
+        "This requires Conda to be installed on your system.",
     )
     parser.add_argument(
-        "-np", "--dry-run",
+        "-np",
+        "--dry-run",
         action="store_true",
-        help="Execute a dry run without actually running the full pipeline."
+        help="Execute a dry run without actually running the full pipeline.",
     )
 
     return parser
 
+
 def main():
     args = gen_parser().parse_args()
-     
+
     # set temp dir if specified, else use python tempfile
     if args.temp_dir:
         temp_dir = args.temp_dir
         os.makedirs(temp_dir, exist_ok=True)
     else:
         temp_dir = tempfile.mkdtemp()
-    
-    # create subject folder 
+
+    # create subject folder
     subject_folder = os.path.join(temp_dir, f"anat/sub-{args.subject}")
-    os.makedirs(subject_folder, exist_ok=True) 
+    os.makedirs(subject_folder, exist_ok=True)
 
     # create new file name
     input_filename = f"sub-{args.subject}_{args.modality}.nii.gz"
-    
+
     # add file name to the created subject folder
     temp_input_file = os.path.join(subject_folder, input_filename)
-    
+
     # copy the input file
-    shutil.copy(args.input, temp_input_file) 
-     
+    shutil.copy(args.input, temp_input_file)
+
     # run hippunfold
     command = [
         "hippunfold",
         temp_dir,
         args.output,
         "participant",
-        "-c", "all",
+        "-c",
+        "all",
         "--force-output",
         "--nolock",
-        "--modality", args.modality
+        "--modality",
+        args.modality,
     ]
 
     if args.use_singularity:
@@ -96,7 +93,7 @@ def main():
     if args.dry_run:
         command.append("-np")
 
-    # run the command 
+    # run the command
     try:
         subprocess.run(command, check=True)
         print("hippunfold completed successfully.")
@@ -106,6 +103,7 @@ def main():
         # delete the temp dir if not user specified
         if not args.temp_dir:
             shutil.rmtree(temp_dir)
- 
+
+
 if __name__ == "__main__":
     main()

--- a/hippunfold/workflow/rules/coords.smk
+++ b/hippunfold/workflow/rules/coords.smk
@@ -192,7 +192,7 @@ rule create_upsampled_coords_ref:
     params:
         tight_crop_labels=lambda wildcards: config["tight_crop_labels"][wildcards.label],
         resample_res=lambda wildcards: config["laminar_coords_res"][wildcards.label],
-        trim_padding="3mm",
+        trim_padding="5mm",
     output:
         upsampled_ref=bids(
             root=work,


### PR DESCRIPTION
This is a quick fix to increase the padding used when making the upsampled reference space for calculating coords -- mainly affects the dentate results (since it is tight cropped around dentate GM).. I was having bad src/sink AP labels that turned out to be because the surface was extending past the volume bounding box for the sdt maps, and thus interpolating a zero.. 

Going to merge this in quickly since I've tested the fix and should have minimal impact.. 