### PR TITLE
Remove work folder, use temp() instead

### DIFF
--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -287,14 +287,6 @@ parse_args:
     action: "store_false"
     default: True
 
-  --workdir:
-    help: |
-      Folder for storing working files. If not specified, will be in "work/" subfolder 
-      in the output folder. You can also use environment variables when setting the 
-      workdir, e.g. --workdir '$SLURM_TMPDIR'.
-    default: work
-    type: str
-
 
   --version:
     help: 'Print the version of HippUnfold'
@@ -696,7 +688,6 @@ force_nnunet_model: False
 t1_reg_template: False
 generate_myelin_map: False
 root: results
-workdir: null
 use_template_seg: False
 template_seg_smoothing_factor: 2
 resample_dsegtissue: null

--- a/hippunfold/workflow/Snakefile
+++ b/hippunfold/workflow/Snakefile
@@ -88,7 +88,6 @@ wildcard_constraints:
     template="[a-zA-Z0-9]+",
 
 
-work = os.path.expandvars(config["workdir"])
 root = os.path.expandvars(config["root"])
 
 

--- a/hippunfold/workflow/rules/common.smk
+++ b/hippunfold/workflow/rules/common.smk
@@ -281,7 +281,7 @@ def get_final_output():
 
 if "corobl" in ref_spaces:
 
-    ruleorder: laplace_beltrami > laynii_layers_equidist > laynii_layers_equivol 
+    ruleorder: laplace_beltrami > laynii_layers_equidist > laynii_layers_equivol
 
 
 def get_cifti_metric_types(label):

--- a/hippunfold/workflow/rules/common.smk
+++ b/hippunfold/workflow/rules/common.smk
@@ -281,39 +281,7 @@ def get_final_output():
 
 if "corobl" in ref_spaces:
 
-    ruleorder: laplace_beltrami > laynii_layers_equidist > laynii_layers_equivol > copy_coords_to_results
-
-    rule copy_coords_to_results:
-        input:
-            os.path.join(work, "{pre}_space-corobl_{post}{suffix}.{ext}"),
-        output:
-            os.path.join(root, "{pre,[^/].+}_space-corobl_{post}{suffix,coords}.{ext}"),
-        group:
-            "subj"
-        shell:
-            "cp {input} {output}"
-
-    rule copy_xfm_to_results:
-        input:
-            os.path.join(work, "{pre}_{fromto}-corobl_{post}{suffix}.{ext}"),
-        output:
-            os.path.join(
-                root, "{pre,[^/].+}_{fromto,from|to}-corobl_{post}{suffix,xfm}.{ext}"
-            ),
-        group:
-            "subj"
-        shell:
-            "cp {input} {output}"
-
-    rule copy_subfields_to_results:
-        input:
-            os.path.join(work, "{pre}_desc-subfields_{post}{suffix}.{ext}"),
-        output:
-            os.path.join(root, "{pre,[^/].+}_desc-subfields_{post}{suffix,dseg}.{ext}"),
-        group:
-            "subj"
-        shell:
-            "cp {input} {output}"
+    ruleorder: laplace_beltrami > laynii_layers_equidist > laynii_layers_equivol 
 
 
 def get_cifti_metric_types(label):
@@ -400,7 +368,7 @@ def get_create_atlas_output():
 def get_input_for_shape_inject(wildcards):
     if config["modality"] == "dsegtissue":
         seg = bids(
-            root=work,
+            root=root,
             datatype="anat",
             **inputs.subj_wildcards,
             suffix="dseg.nii.gz",
@@ -409,7 +377,7 @@ def get_input_for_shape_inject(wildcards):
         ).format(**wildcards)
     else:
         seg = bids(
-            root=work,
+            root=root,
             datatype="anat",
             **inputs.subj_wildcards,
             suffix="dseg.nii.gz",

--- a/hippunfold/workflow/rules/coords.smk
+++ b/hippunfold/workflow/rules/coords.smk
@@ -6,7 +6,7 @@ def get_labels_for_laplace(wildcards):
         seg = get_input_for_shape_inject(wildcards)
     else:
         seg = bids(
-            root=work,
+            root=root,
             datatype="anat",
             **inputs.subj_wildcards,
             suffix="dseg.nii.gz",
@@ -56,15 +56,17 @@ rule get_label_mask:
     params:
         labels=get_gm_labels,
     output:
-        mask=bids(
-            root=work,
-            datatype="coords",
-            suffix="mask.nii.gz",
-            space="corobl",
-            desc="GM",
-            hemi="{hemi}",
-            label="{label}",
-            **inputs.subj_wildcards,
+        mask=temp(
+            bids(
+                root=root,
+                datatype="coords",
+                suffix="mask.nii.gz",
+                space="corobl",
+                desc="GM",
+                hemi="{hemi}",
+                label="{label}",
+                **inputs.subj_wildcards,
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -82,7 +84,7 @@ def get_inputs_laplace(wildcards):
     if not config["skip_inject_template_labels"]:
         files["init_coords"] = (
             bids(
-                root=work,
+                root=root,
                 datatype="coords",
                 **inputs.subj_wildcards,
                 dir="{dir}",
@@ -102,16 +104,18 @@ rule get_src_sink_mask:
     params:
         labels=get_src_sink_labels,
     output:
-        mask=bids(
-            root=work,
-            datatype="coords",
-            suffix="mask.nii.gz",
-            space="corobl",
-            dir="{dir}",
-            desc="{srcsink,src|sink}",
-            hemi="{hemi}",
-            label="{label}",
-            **inputs.subj_wildcards,
+        mask=temp(
+            bids(
+                root=root,
+                datatype="coords",
+                suffix="mask.nii.gz",
+                space="corobl",
+                dir="{dir}",
+                desc="{srcsink,src|sink}",
+                hemi="{hemi}",
+                label="{label}",
+                **inputs.subj_wildcards,
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -127,7 +131,7 @@ rule get_src_sink_sdt:
     """calculate signed distance transform (negative inside, positive outside)"""
     input:
         mask=bids(
-            root=work,
+            root=root,
             datatype="coords",
             suffix="mask.nii.gz",
             space="corobl",
@@ -138,16 +142,18 @@ rule get_src_sink_sdt:
             **inputs.subj_wildcards,
         ),
     output:
-        sdt=bids(
-            root=work,
-            datatype="coords",
-            suffix="sdt.nii.gz",
-            space="corobl",
-            dir="{dir}",
-            desc="{srcsink}",
-            hemi="{hemi}",
-            label="{label}",
-            **inputs.subj_wildcards,
+        sdt=temp(
+            bids(
+                root=root,
+                datatype="coords",
+                suffix="sdt.nii.gz",
+                space="corobl",
+                dir="{dir}",
+                desc="{srcsink}",
+                hemi="{hemi}",
+                label="{label}",
+                **inputs.subj_wildcards,
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -165,16 +171,18 @@ rule get_nan_mask:
     params:
         labels=get_nan_labels,
     output:
-        mask=bids(
-            root=work,
-            datatype="coords",
-            suffix="mask.nii.gz",
-            space="corobl",
-            dir="{dir}",
-            desc="nan",
-            hemi="{hemi}",
-            label="{label}",
-            **inputs.subj_wildcards,
+        mask=temp(
+            bids(
+                root=root,
+                datatype="coords",
+                suffix="mask.nii.gz",
+                space="corobl",
+                dir="{dir}",
+                desc="nan",
+                hemi="{hemi}",
+                label="{label}",
+                **inputs.subj_wildcards,
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -194,15 +202,17 @@ rule create_upsampled_coords_ref:
         resample_res=lambda wildcards: config["laminar_coords_res"][wildcards.label],
         trim_padding="5mm",
     output:
-        upsampled_ref=bids(
-            root=work,
-            datatype="anat",
-            **inputs.subj_wildcards,
-            suffix="ref.nii.gz",
-            desc="resampled",
-            space="corobl",
-            label="{label}",
-            hemi="{hemi}",
+        upsampled_ref=temp(
+            bids(
+                root=root,
+                datatype="anat",
+                **inputs.subj_wildcards,
+                suffix="ref.nii.gz",
+                desc="resampled",
+                space="corobl",
+                label="{label}",
+                hemi="{hemi}",
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -245,16 +255,18 @@ rule prep_dseg_for_laynii:
             ]
         ),
     output:
-        dseg_rim=bids(
-            root=work,
-            datatype="anat",
-            **inputs.subj_wildcards,
-            suffix="dseg.nii.gz",
-            dir="{dir,IO}",
-            desc="laynii",
-            label="{label}",
-            space="corobl",
-            hemi="{hemi}",
+        dseg_rim=temp(
+            bids(
+                root=root,
+                datatype="anat",
+                **inputs.subj_wildcards,
+                suffix="dseg.nii.gz",
+                dir="{dir,IO}",
+                desc="laynii",
+                label="{label}",
+                space="corobl",
+                hemi="{hemi}",
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -269,7 +281,7 @@ rule prep_dseg_for_laynii:
 rule laynii_layers_equidist:
     input:
         dseg_rim=bids(
-            root=work,
+            root=root,
             datatype="anat",
             **inputs.subj_wildcards,
             suffix="dseg.nii.gz",
@@ -280,16 +292,18 @@ rule laynii_layers_equidist:
             hemi="{hemi}",
         ),
     output:
-        equidist=bids(
-            root=work,
-            datatype="coords",
-            dir="{dir,IO}",
-            label="{label}",
-            suffix="coords.nii.gz",
-            desc="equidist",
-            space="corobl",
-            hemi="{hemi}",
-            **inputs.subj_wildcards,
+        equidist=temp(
+            bids(
+                root=root,
+                datatype="coords",
+                dir="{dir,IO}",
+                label="{label}",
+                suffix="coords.nii.gz",
+                desc="equidist",
+                space="corobl",
+                hemi="{hemi}",
+                **inputs.subj_wildcards,
+            )
         ),
     shadow:
         "minimal"
@@ -308,7 +322,7 @@ rule laynii_layers_equidist:
 rule laynii_layers_equivol:
     input:
         dseg_rim=bids(
-            root=work,
+            root=root,
             datatype="anat",
             **inputs.subj_wildcards,
             suffix="dseg.nii.gz",
@@ -319,16 +333,18 @@ rule laynii_layers_equivol:
             hemi="{hemi}",
         ),
     output:
-        equivol=bids(
-            root=work,
-            datatype="coords",
-            dir="{dir,IO}",
-            label="{label}",
-            suffix="coords.nii.gz",
-            desc="equivol",
-            space="corobl",
-            hemi="{hemi}",
-            **inputs.subj_wildcards,
+        equivol=temp(
+            bids(
+                root=root,
+                datatype="coords",
+                dir="{dir,IO}",
+                label="{label}",
+                suffix="coords.nii.gz",
+                desc="equivol",
+                space="corobl",
+                hemi="{hemi}",
+                **inputs.subj_wildcards,
+            )
         ),
     shadow:
         "minimal"

--- a/hippunfold/workflow/rules/download.smk
+++ b/hippunfold/workflow/rules/download.smk
@@ -54,14 +54,16 @@ rule import_template_dseg:
             ),
         ),
     output:
-        template_seg=bids(
-            root=work,
-            datatype="anat",
-            space="template",
-            **inputs.subj_wildcards,
-            desc="hipptissue",
-            hemi="{hemi}",
-            suffix="dseg.nii.gz",
+        template_seg=temp(
+            bids(
+                root=root,
+                datatype="anat",
+                space="template",
+                **inputs.subj_wildcards,
+                desc="hipptissue",
+                hemi="{hemi}",
+                suffix="dseg.nii.gz",
+            )
         ),
     group:
         "subj"
@@ -93,14 +95,16 @@ rule import_template_dseg_dentate:
             ].format(**wildcards),
         ),
     output:
-        template_seg=bids(
-            root=work,
-            datatype="anat",
-            space="template",
-            **inputs.subj_wildcards,
-            desc="dentatetissue",
-            hemi="{hemi}",
-            suffix="dseg.nii.gz",
+        template_seg=temp(
+            bids(
+                root=root,
+                datatype="anat",
+                space="template",
+                **inputs.subj_wildcards,
+                desc="dentatetissue",
+                hemi="{hemi}",
+                suffix="dseg.nii.gz",
+            )
         ),
     group:
         "subj"
@@ -132,16 +136,18 @@ rule import_template_coords:
             ),
         ),
     output:
-        template_coords=bids(
-            root=work,
-            datatype="coords",
-            **inputs.subj_wildcards,
-            dir="{dir}",
-            label="{label}",
-            suffix="coords.nii.gz",
-            desc="init",
-            space="template",
-            hemi="{hemi}",
+        template_coords=temp(
+            bids(
+                root=root,
+                datatype="coords",
+                **inputs.subj_wildcards,
+                dir="{dir}",
+                label="{label}",
+                suffix="coords.nii.gz",
+                desc="init",
+                space="template",
+                hemi="{hemi}",
+            )
         ),
     group:
         "subj"
@@ -173,14 +179,16 @@ rule import_template_anat:
             ].format(**wildcards),
         ),
     output:
-        template_anat=bids(
-            root=work,
-            datatype="anat",
-            space="template",
-            **inputs.subj_wildcards,
-            hemi="{hemi}",
-            suffix="{modality}.nii.gz".format(
-                modality=get_modality_suffix(config["modality"])
+        template_anat=temp(
+            bids(
+                root=root,
+                datatype="anat",
+                space="template",
+                **inputs.subj_wildcards,
+                hemi="{hemi}",
+                suffix="{modality}.nii.gz".format(
+                    modality=get_modality_suffix(config["modality"])
+                ),
             ),
         ),
     group:

--- a/hippunfold/workflow/rules/gifti.smk
+++ b/hippunfold/workflow/rules/gifti.smk
@@ -23,7 +23,7 @@ surf_to_secondary_type = {
 rule affine_gii_to_native:
     input:
         gii=bids(
-            root=work,
+            root=root,
             datatype="surf",
             den="{density}",
             suffix="{surfname}.surf.gii",
@@ -33,7 +33,7 @@ rule affine_gii_to_native:
             **inputs.subj_wildcards,
         ),
         xfm=bids(
-            root=work,
+            root=root,
             datatype="warps",
             **inputs.subj_wildcards,
             suffix="xfm.txt",

--- a/hippunfold/workflow/rules/myelin_map.smk
+++ b/hippunfold/workflow/rules/myelin_map.smk
@@ -2,7 +2,7 @@
 rule divide_t1_by_t2:
     input:
         t1=bids(
-            root=work,
+            root=root,
             datatype="anat",
             hemi="{hemi}",
             space="corobl",
@@ -11,7 +11,7 @@ rule divide_t1_by_t2:
             **inputs.subj_wildcards,
         ),
         t2=bids(
-            root=work,
+            root=root,
             datatype="anat",
             hemi="{hemi}",
             space="corobl",
@@ -20,14 +20,16 @@ rule divide_t1_by_t2:
             **inputs.subj_wildcards,
         ),
     output:
-        t1overt2=bids(
-            root=work,
-            datatype="anat",
-            hemi="{hemi}",
-            space="corobl",
-            desc="preproc",
-            suffix="T1wDividedByT2w.nii.gz",
-            **inputs.subj_wildcards,
+        t1overt2=temp(
+            bids(
+                root=root,
+                datatype="anat",
+                hemi="{hemi}",
+                space="corobl",
+                desc="preproc",
+                suffix="T1wDividedByT2w.nii.gz",
+                **inputs.subj_wildcards,
+            )
         ),
     group:
         "subj"
@@ -44,7 +46,7 @@ rule sample_myelin_map_surf:
     """ samples myelin map on surf using corobl space """
     input:
         vol=bids(
-            root=work,
+            root=root,
             datatype="anat",
             space="corobl",
             hemi="{hemi}",
@@ -53,7 +55,7 @@ rule sample_myelin_map_surf:
             **inputs.subj_wildcards,
         ),
         mid=bids(
-            root=work,
+            root=root,
             datatype="surf",
             suffix="midthickness.surf.gii",
             space="corobl",
@@ -62,7 +64,7 @@ rule sample_myelin_map_surf:
             **inputs.subj_wildcards,
         ),
         inner=bids(
-            root=work,
+            root=root,
             datatype="surf",
             suffix="inner.surf.gii",
             space="corobl",
@@ -71,7 +73,7 @@ rule sample_myelin_map_surf:
             **inputs.subj_wildcards,
         ),
         outer=bids(
-            root=work,
+            root=root,
             datatype="surf",
             suffix="outer.surf.gii",
             space="corobl",

--- a/hippunfold/workflow/rules/native_surf.smk
+++ b/hippunfold/workflow/rules/native_surf.smk
@@ -15,7 +15,7 @@ ruleorder: atlas_label_to_unfold_nii > atlas_metric_to_unfold_nii
 rule gen_native_mesh:
     input:
         coords=lambda wildcards: bids(
-            root=work,
+            root=root,
             datatype="coords",
             dir="IO",
             label="{label}",
@@ -26,7 +26,7 @@ rule gen_native_mesh:
             **inputs.subj_wildcards,
         ),
         nan_mask=bids(
-            root=work,
+            root=root,
             datatype="coords",
             suffix="mask.nii.gz",
             space="corobl",
@@ -37,7 +37,7 @@ rule gen_native_mesh:
             **inputs.subj_wildcards,
         ),
         sink_mask=bids(
-            root=work,
+            root=root,
             datatype="coords",
             suffix="mask.nii.gz",
             space="corobl",
@@ -48,7 +48,7 @@ rule gen_native_mesh:
             **inputs.subj_wildcards,
         ),
         src_mask=bids(
-            root=work,
+            root=root,
             datatype="coords",
             suffix="mask.nii.gz",
             space="corobl",
@@ -70,15 +70,17 @@ rule gen_native_mesh:
         coords_epsilon=0.1,
     output:
         surf_gii=temp(
-            bids(
-                root=work,
-                datatype="surf",
-                suffix="{surfname,midthickness}.surf.gii",
-                space="corobl",
-                desc="nostruct",
-                hemi="{hemi}",
-                label="{label}",
-                **inputs.subj_wildcards,
+            temp(
+                bids(
+                    root=root,
+                    datatype="surf",
+                    suffix="{surfname,midthickness}.surf.gii",
+                    space="corobl",
+                    desc="nostruct",
+                    hemi="{hemi}",
+                    label="{label}",
+                    **inputs.subj_wildcards,
+                )
             )
         ),
     log:
@@ -104,7 +106,7 @@ rule gen_native_mesh:
 rule update_native_mesh_structure:
     input:
         surf_gii=bids(
-            root=work,
+            root=root,
             datatype="surf",
             suffix="{surfname}.surf.gii",
             space="{space}",
@@ -118,14 +120,16 @@ rule update_native_mesh_structure:
         secondary_type=lambda wildcards: surf_to_secondary_type[wildcards.surfname],
         surface_type="ANATOMICAL",
     output:
-        surf_gii=bids(
-            root=work,
-            datatype="surf",
-            suffix="{surfname,midthickness|inner|outer}.surf.gii",
-            space="{space,corobl|unfold}",
-            hemi="{hemi}",
-            label="{label}",
-            **inputs.subj_wildcards,
+        surf_gii=temp(
+            bids(
+                root=root,
+                datatype="surf",
+                suffix="{surfname,midthickness|inner|outer}.surf.gii",
+                space="{space,corobl|unfold}",
+                hemi="{hemi}",
+                label="{label}",
+                **inputs.subj_wildcards,
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -154,15 +158,17 @@ rule smooth_surface:
         smoothing_strength=0.8,
         smoothing_iterations=10,
     output:
-        surf_gii=bids(
-            root=work,
-            datatype="surf",
-            suffix="{surfname}.surf.gii",
-            space="corobl",
-            desc="smoothed",
-            hemi="{hemi}",
-            label="{label}",
-            **inputs.subj_wildcards,
+        surf_gii=temp(
+            bids(
+                root=root,
+                datatype="surf",
+                suffix="{surfname}.surf.gii",
+                space="corobl",
+                desc="smoothed",
+                hemi="{hemi}",
+                label="{label}",
+                **inputs.subj_wildcards,
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -189,14 +195,16 @@ rule get_boundary_vertices:
             **inputs.subj_wildcards,
         ),
     output:
-        label_gii=bids(
-            root=work,
-            datatype="coords",
-            suffix="boundary.label.gii",
-            space="corobl",
-            hemi="{hemi}",
-            label="{label}",
-            **inputs.subj_wildcards,
+        label_gii=temp(
+            bids(
+                root=root,
+                datatype="coords",
+                suffix="boundary.label.gii",
+                space="corobl",
+                hemi="{hemi}",
+                label="{label}",
+                **inputs.subj_wildcards,
+            )
         ),
     group:
         "subj"
@@ -221,7 +229,7 @@ rule map_src_sink_sdt_to_surf:
             **inputs.subj_wildcards,
         ),
         sdt=bids(
-            root=work,
+            root=root,
             datatype="coords",
             suffix="sdt.nii.gz",
             space="corobl",
@@ -232,16 +240,18 @@ rule map_src_sink_sdt_to_surf:
             **inputs.subj_wildcards,
         ),
     output:
-        sdt=bids(
-            root=work,
-            datatype="coords",
-            suffix="sdt.shape.gii",
-            space="corobl",
-            hemi="{hemi}",
-            dir="{dir}",
-            desc="{srcsink}",
-            label="{label}",
-            **inputs.subj_wildcards,
+        sdt=temp(
+            bids(
+                root=root,
+                datatype="coords",
+                suffix="sdt.shape.gii",
+                space="corobl",
+                hemi="{hemi}",
+                dir="{dir}",
+                desc="{srcsink}",
+                label="{label}",
+                **inputs.subj_wildcards,
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -257,7 +267,7 @@ rule postproc_boundary_vertices:
     """ ensures non-overlapping and full labelling of AP/PD edges """
     input:
         ap_src=bids(
-            root=work,
+            root=root,
             datatype="coords",
             suffix="sdt.shape.gii",
             space="corobl",
@@ -268,7 +278,7 @@ rule postproc_boundary_vertices:
             **inputs.subj_wildcards,
         ),
         ap_sink=bids(
-            root=work,
+            root=root,
             datatype="coords",
             suffix="sdt.shape.gii",
             space="corobl",
@@ -279,7 +289,7 @@ rule postproc_boundary_vertices:
             **inputs.subj_wildcards,
         ),
         pd_src=bids(
-            root=work,
+            root=root,
             datatype="coords",
             suffix="sdt.shape.gii",
             space="corobl",
@@ -290,7 +300,7 @@ rule postproc_boundary_vertices:
             **inputs.subj_wildcards,
         ),
         pd_sink=bids(
-            root=work,
+            root=root,
             datatype="coords",
             suffix="sdt.shape.gii",
             space="corobl",
@@ -301,7 +311,7 @@ rule postproc_boundary_vertices:
             **inputs.subj_wildcards,
         ),
         edges=bids(
-            root=work,
+            root=root,
             datatype="coords",
             suffix="boundary.label.gii",
             space="corobl",
@@ -315,7 +325,7 @@ rule postproc_boundary_vertices:
         shifting_epsilon=0.1,  #could be proportional to voxel spacing
     output:
         ap=bids(
-            root=work,
+            root=root,
             datatype="coords",
             suffix="mask.label.gii",
             space="corobl",
@@ -325,16 +335,18 @@ rule postproc_boundary_vertices:
             label="{label}",
             **inputs.subj_wildcards,
         ),
-        pd=bids(
-            root=work,
-            datatype="coords",
-            suffix="mask.label.gii",
-            space="corobl",
-            hemi="{hemi}",
-            dir="PD",
-            desc="srcsink",
-            label="{label}",
-            **inputs.subj_wildcards,
+        pd=temp(
+            bids(
+                root=root,
+                datatype="coords",
+                suffix="mask.label.gii",
+                space="corobl",
+                hemi="{hemi}",
+                dir="PD",
+                desc="srcsink",
+                label="{label}",
+                **inputs.subj_wildcards,
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -367,7 +379,7 @@ rule laplace_beltrami:
             **inputs.subj_wildcards,
         ),
         src_sink_mask=bids(
-            root=work,
+            root=root,
             datatype="coords",
             suffix="mask.label.gii",
             space="corobl",
@@ -378,16 +390,18 @@ rule laplace_beltrami:
             **inputs.subj_wildcards,
         ),
     output:
-        coords=bids(
-            root=work,
-            datatype="coords",
-            dir="{dir}",
-            suffix="coords.shape.gii",
-            desc="laplace",
-            space="corobl",
-            hemi="{hemi}",
-            label="{label}",
-            **inputs.subj_wildcards,
+        coords=temp(
+            bids(
+                root=root,
+                datatype="coords",
+                dir="{dir}",
+                suffix="coords.shape.gii",
+                desc="laplace",
+                space="corobl",
+                hemi="{hemi}",
+                label="{label}",
+                **inputs.subj_wildcards,
+            )
         ),
     log:
         bids(
@@ -429,7 +443,7 @@ rule warp_native_mesh_to_unfold:
             **inputs.subj_wildcards,
         ),
         coords_AP=bids(
-            root=work,
+            root=root,
             datatype="coords",
             dir="AP",
             label="{label}",
@@ -440,7 +454,7 @@ rule warp_native_mesh_to_unfold:
             **inputs.subj_wildcards,
         ),
         coords_PD=bids(
-            root=work,
+            root=root,
             datatype="coords",
             dir="PD",
             label="{label}",
@@ -454,15 +468,17 @@ rule warp_native_mesh_to_unfold:
         vertspace=lambda wildcards: config["unfold_vol_ref"][wildcards.label],
         z_level=get_unfold_z_level,
     output:
-        surf_gii=bids(
-            root=work,
-            datatype="surf",
-            suffix="{surfname,midthickness}.surf.gii",
-            desc="nostruct",
-            space="unfolduneven",
-            hemi="{hemi}",
-            label="{label}",
-            **inputs.subj_wildcards,
+        surf_gii=temp(
+            bids(
+                root=root,
+                datatype="surf",
+                suffix="{surfname,midthickness}.surf.gii",
+                desc="nostruct",
+                space="unfolduneven",
+                hemi="{hemi}",
+                label="{label}",
+                **inputs.subj_wildcards,
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -481,7 +497,7 @@ rule space_unfold_vertices:
         would be similar to native) """
     input:
         surf_gii=bids(
-            root=work,
+            root=root,
             datatype="surf",
             suffix="midthickness.surf.gii",
             desc="nostruct",
@@ -491,7 +507,7 @@ rule space_unfold_vertices:
             **inputs.subj_wildcards,
         ),
         native_gii=bids(
-            root=work,
+            root=root,
             datatype="surf",
             suffix="midthickness.surf.gii",
             space="corobl",
@@ -503,15 +519,17 @@ rule space_unfold_vertices:
         step_size=0.1,
         max_iterations=10000,
     output:
-        surf_gii=bids(
-            root=work,
-            datatype="surf",
-            suffix="midthickness.surf.gii",
-            desc="nostruct",
-            space="unfoldspringmodel",
-            hemi="{hemi}",
-            label="{label}",
-            **inputs.subj_wildcards,
+        surf_gii=temp(
+            bids(
+                root=root,
+                datatype="surf",
+                suffix="midthickness.surf.gii",
+                desc="nostruct",
+                space="unfoldspringmodel",
+                hemi="{hemi}",
+                label="{label}",
+                **inputs.subj_wildcards,
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -535,7 +553,7 @@ rule space_unfold_vertices:
 rule unfold_surface_smoothing:
     input:
         surf_gii=bids(
-            root=work,
+            root=root,
             datatype="surf",
             suffix="midthickness.surf.gii",
             desc="nostruct",
@@ -548,15 +566,17 @@ rule unfold_surface_smoothing:
         strength=1,
         iterations=5,
     output:
-        surf_gii=bids(
-            root=work,
-            datatype="surf",
-            suffix="midthickness.surf.gii",
-            desc="nostruct",
-            space="unfold",
-            hemi="{hemi}",
-            label="{label}",
-            **inputs.subj_wildcards,
+        surf_gii=temp(
+            bids(
+                root=root,
+                datatype="surf",
+                suffix="midthickness.surf.gii",
+                desc="nostruct",
+                space="unfold",
+                hemi="{hemi}",
+                label="{label}",
+                **inputs.subj_wildcards,
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -571,7 +591,7 @@ rule unfold_surface_smoothing:
 rule set_surface_z_level:
     input:
         surf_gii=bids(
-            root=work,
+            root=root,
             datatype="surf",
             suffix="midthickness.surf.gii",
             desc="nostruct",
@@ -583,15 +603,17 @@ rule set_surface_z_level:
     params:
         z_level=get_unfold_z_level,
     output:
-        surf_gii=bids(
-            root=work,
-            datatype="surf",
-            suffix="{surfname,inner|outer}.surf.gii",
-            desc="nostruct",
-            space="unfold",
-            hemi="{hemi}",
-            label="{label}",
-            **inputs.subj_wildcards,
+        surf_gii=temp(
+            bids(
+                root=root,
+                datatype="surf",
+                suffix="{surfname,inner|outer}.surf.gii",
+                desc="nostruct",
+                space="unfold",
+                hemi="{hemi}",
+                label="{label}",
+                **inputs.subj_wildcards,
+            )
         ),
     group:
         "subj"
@@ -609,7 +631,7 @@ rule set_surface_z_level:
 rule compute_halfthick_mask:
     input:
         coords=lambda wildcards: bids(
-            root=work,
+            root=root,
             datatype="coords",
             dir="IO",
             label="{label}",
@@ -620,7 +642,7 @@ rule compute_halfthick_mask:
             **inputs.subj_wildcards,
         ),
         mask=bids(
-            root=work,
+            root=root,
             datatype="coords",
             suffix="mask.nii.gz",
             space="corobl",
@@ -635,16 +657,18 @@ rule compute_halfthick_mask:
         ),
     output:
         nii=temp(
-            bids(
-                root=work,
-                datatype="surf",
-                dir="IO",
-                label="{label}",
-                suffix="mask.nii.gz",
-                to="{inout}",
-                space="corobl",
-                hemi="{hemi}",
-                **inputs.subj_wildcards,
+            temp(
+                bids(
+                    root=root,
+                    datatype="surf",
+                    dir="IO",
+                    label="{label}",
+                    suffix="mask.nii.gz",
+                    to="{inout}",
+                    space="corobl",
+                    hemi="{hemi}",
+                    **inputs.subj_wildcards,
+                )
             )
         ),
     group:
@@ -660,7 +684,7 @@ rule compute_halfthick_mask:
 rule register_midthickness:
     input:
         fixed=bids(
-            root=work,
+            root=root,
             datatype="surf",
             dir="IO",
             label="{label}",
@@ -671,7 +695,7 @@ rule register_midthickness:
             **inputs.subj_wildcards,
         ),
         moving=bids(
-            root=work,
+            root=root,
             datatype="coords",
             suffix="mask.nii.gz",
             space="corobl",
@@ -682,16 +706,18 @@ rule register_midthickness:
         ),
     output:
         warp=temp(
-            bids(
-                root=work,
-                datatype="surf",
-                dir="IO",
-                label="{label}",
-                suffix="xfm.nii.gz",
-                to="{inout}",
-                space="corobl",
-                hemi="{hemi}",
-                **inputs.subj_wildcards,
+            temp(
+                bids(
+                    root=root,
+                    datatype="surf",
+                    dir="IO",
+                    label="{label}",
+                    suffix="xfm.nii.gz",
+                    to="{inout}",
+                    space="corobl",
+                    hemi="{hemi}",
+                    **inputs.subj_wildcards,
+                )
             )
         ),
     log:
@@ -721,7 +747,7 @@ rule register_midthickness:
 rule apply_halfsurf_warp_to_img:
     input:
         fixed=bids(
-            root=work,
+            root=root,
             datatype="surf",
             dir="IO",
             label="{label}",
@@ -732,7 +758,7 @@ rule apply_halfsurf_warp_to_img:
             **inputs.subj_wildcards,
         ),
         moving=bids(
-            root=work,
+            root=root,
             datatype="coords",
             suffix="mask.nii.gz",
             space="corobl",
@@ -742,7 +768,7 @@ rule apply_halfsurf_warp_to_img:
             **inputs.subj_wildcards,
         ),
         warp=bids(
-            root=work,
+            root=root,
             datatype="surf",
             dir="IO",
             label="{label}",
@@ -754,16 +780,18 @@ rule apply_halfsurf_warp_to_img:
         ),
     output:
         warped=temp(
-            bids(
-                root=work,
-                datatype="surf",
-                dir="IO",
-                label="{label}",
-                suffix="warpedmask.nii.gz",
-                to_="{inout}",
-                space="corobl",
-                hemi="{hemi}",
-                **inputs.subj_wildcards,
+            temp(
+                bids(
+                    root=root,
+                    datatype="surf",
+                    dir="IO",
+                    label="{label}",
+                    suffix="warpedmask.nii.gz",
+                    to_="{inout}",
+                    space="corobl",
+                    hemi="{hemi}",
+                    **inputs.subj_wildcards,
+                )
             )
         ),
     group:
@@ -780,7 +808,7 @@ rule apply_halfsurf_warp_to_img:
 rule convert_inout_warp_from_itk_to_world:
     input:
         warp=bids(
-            root=work,
+            root=root,
             datatype="surf",
             dir="IO",
             label="{label}",
@@ -792,16 +820,18 @@ rule convert_inout_warp_from_itk_to_world:
         ),
     output:
         warp=temp(
-            bids(
-                root=work,
-                datatype="surf",
-                dir="IO",
-                label="{label}",
-                suffix="xfmras.nii.gz",
-                to="{inout}",
-                space="corobl",
-                hemi="{hemi}",
-                **inputs.subj_wildcards,
+            temp(
+                bids(
+                    root=root,
+                    datatype="surf",
+                    dir="IO",
+                    label="{label}",
+                    suffix="xfmras.nii.gz",
+                    to="{inout}",
+                    space="corobl",
+                    hemi="{hemi}",
+                    **inputs.subj_wildcards,
+                )
             )
         ),
     group:
@@ -826,7 +856,7 @@ rule warp_midthickness_to_inout:
             **inputs.subj_wildcards,
         ),
         warp=bids(
-            root=work,
+            root=root,
             datatype="surf",
             dir="IO",
             label="{label}",
@@ -841,14 +871,16 @@ rule warp_midthickness_to_inout:
         secondary_type=lambda wildcards: surf_to_secondary_type[wildcards.surfname],
         surface_type="ANATOMICAL",
     output:
-        surf_gii=bids(
-            root=work,
-            datatype="surf",
-            suffix="{surfname,inner|outer}.surf.gii",
-            space="corobl",
-            hemi="{hemi}",
-            label="{label}",
-            **inputs.subj_wildcards,
+        surf_gii=temp(
+            bids(
+                root=root,
+                datatype="surf",
+                suffix="{surfname,inner|outer}.surf.gii",
+                space="corobl",
+                hemi="{hemi}",
+                label="{label}",
+                **inputs.subj_wildcards,
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -881,7 +913,7 @@ rule affine_gii_corobl_to_modality:
             **inputs.subj_wildcards,
         ),
         xfm=bids(
-            root=work,
+            root=root,
             datatype="warps",
             **inputs.subj_wildcards,
             suffix="xfm.txt",
@@ -925,14 +957,16 @@ rule calculate_surface_area:
             **inputs.subj_wildcards,
         ),
     output:
-        gii=bids(
-            root=work,
-            datatype="surf",
-            suffix="surfarea.shape.gii",
-            space="{space}",
-            hemi="{hemi}",
-            label="{label}",
-            **inputs.subj_wildcards,
+        gii=temp(
+            bids(
+                root=root,
+                datatype="surf",
+                suffix="surfarea.shape.gii",
+                space="{space}",
+                hemi="{hemi}",
+                label="{label}",
+                **inputs.subj_wildcards,
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -949,7 +983,7 @@ rule calculate_legacy_gyrification:
     this should be proportional by a constant, to the earlier gyrification on 32k surfaces."""
     input:
         native_surfarea=bids(
-            root=work,
+            root=root,
             datatype="surf",
             suffix="surfarea.shape.gii",
             space="corobl",
@@ -958,7 +992,7 @@ rule calculate_legacy_gyrification:
             **inputs.subj_wildcards,
         ),
         unfold_surfarea=bids(
-            root=work,
+            root=root,
             datatype="surf",
             suffix="surfarea.shape.gii",
             space="unfold",
@@ -990,7 +1024,7 @@ rule calculate_legacy_gyrification:
 rule calculate_curvature:
     input:
         gii=bids(
-            root=work,
+            root=root,
             datatype="surf",
             suffix="midthickness.surf.gii",
             space="corobl",
@@ -1093,7 +1127,7 @@ def get_unfold_ref(wildcards):
 rule cp_surf_to_root:
     input:
         native_resampled=bids(
-            root=work,
+            root=root,
             datatype="surf",
             suffix="{surf_name}.surf.gii",
             space="{space}",
@@ -1127,7 +1161,7 @@ rule resample_native_surf_to_atlas_density:
     """
     input:
         native=bids(
-            root=work,
+            root=root,
             datatype="surf",
             suffix="{surf_name}.surf.gii",
             space="{space}",
@@ -1145,15 +1179,17 @@ rule resample_native_surf_to_atlas_density:
         ),
         native_unfold=get_unfold_ref,
     output:
-        native_resampled=bids(
-            root=work,
-            datatype="surf",
-            suffix="{surf_name,midthickness|inner|outer}.surf.gii",
-            space="{space,unfoldreg|corobl}",
-            den=config["atlas"],
-            hemi="{hemi}",
-            label="{label}",
-            **inputs.subj_wildcards,
+        native_resampled=temp(
+            bids(
+                root=root,
+                datatype="surf",
+                suffix="{surf_name,midthickness|inner|outer}.surf.gii",
+                space="{space,unfoldreg|corobl}",
+                den=config["atlas"],
+                hemi="{hemi}",
+                label="{label}",
+                **inputs.subj_wildcards,
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -1285,7 +1321,7 @@ rule atlas_label_to_unfold_nii:
 """
     input:
         ref_nii=bids(
-            root=work,
+            root=root,
             space="unfold",
             label="{label}",
             datatype="warps",
@@ -1308,15 +1344,17 @@ rule atlas_label_to_unfold_nii:
             suffix="midthickness.surf.gii",
         ),
     output:
-        label_nii=bids(
-            root=work,
-            datatype="anat",
-            suffix="subfields.nii.gz",
-            space="unfold",
-            hemi="{hemi}",
-            label="{label}",
-            atlas="{atlas}",
-            **inputs.subj_wildcards,
+        label_nii=temp(
+            bids(
+                root=root,
+                datatype="anat",
+                suffix="subfields.nii.gz",
+                space="unfold",
+                hemi="{hemi}",
+                label="{label}",
+                atlas="{atlas}",
+                **inputs.subj_wildcards,
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -1670,7 +1708,7 @@ rule merge_hipp_dentate_spec_file:
 rule cp_native_surf_to_root:
     input:
         native=bids(
-            root=work,
+            root=root,
             datatype="surf",
             suffix="{surf_name}.surf.gii",
             space="{space}",

--- a/hippunfold/workflow/rules/nnunet.smk
+++ b/hippunfold/workflow/rules/nnunet.smk
@@ -3,7 +3,7 @@ import re
 
 def get_nnunet_input(wildcards):
     T1w_nii = bids(
-        root=work,
+        root=root,
         datatype="anat",
         space="corobl",
         desc="preproc",
@@ -12,7 +12,7 @@ def get_nnunet_input(wildcards):
         **inputs.subj_wildcards,
     )
     T2w_nii = bids(
-        root=work,
+        root=root,
         datatype="anat",
         space="corobl",
         desc="preproc",
@@ -31,7 +31,7 @@ def get_nnunet_input(wildcards):
         return T1w_nii
     elif config["modality"] == "hippb500":
         return bids(
-            root=work,
+            root=root,
             datatype="dwi",
             hemi="{hemi}",
             space="corobl",
@@ -128,14 +128,16 @@ rule run_inference:
         trainer=parse_trainer_from_tar,
         tta="" if config["nnunet_enable_tta"] else "--disable_tta",
     output:
-        nnunet_seg=bids(
-            root=work,
-            datatype="anat",
-            **inputs.subj_wildcards,
-            suffix="dseg.nii.gz",
-            desc="nnunet",
-            space="corobl",
-            hemi="{hemi}",
+        nnunet_seg=temp(
+            bids(
+                root=root,
+                datatype="anat",
+                **inputs.subj_wildcards,
+                suffix="dseg.nii.gz",
+                desc="nnunet",
+                space="corobl",
+                hemi="{hemi}",
+            )
         ),
     log:
         bids(
@@ -193,7 +195,7 @@ rule qc_nnunet_f3d:
     input:
         img=(
             bids(
-                root=work,
+                root=root,
                 datatype="anat",
                 **inputs.subj_wildcards,
                 suffix="{modality}.nii.gz".format(modality=config["modality"]),
@@ -203,7 +205,7 @@ rule qc_nnunet_f3d:
             ),
         ),
         seg=bids(
-            root=work,
+            root=root,
             datatype="anat",
             **inputs.subj_wildcards,
             suffix="dseg.nii.gz",
@@ -216,7 +218,7 @@ rule qc_nnunet_f3d:
         ref=get_f3d_ref,
     output:
         cpp=bids(
-            root=work,
+            root=root,
             datatype="warps",
             **inputs.subj_wildcards,
             suffix="cpp.nii.gz",
@@ -225,7 +227,7 @@ rule qc_nnunet_f3d:
             hemi="{hemi}",
         ),
         res=bids(
-            root=work,
+            root=root,
             datatype="anat",
             **inputs.subj_wildcards,
             suffix="{modality}.nii.gz".format(modality=config["modality"]),
@@ -233,14 +235,16 @@ rule qc_nnunet_f3d:
             space="template",
             hemi="{hemi}",
         ),
-        res_mask=bids(
-            root=work,
-            datatype="anat",
-            **inputs.subj_wildcards,
-            suffix="mask.nii.gz",
-            desc="f3d",
-            space="template",
-            hemi="{hemi}",
+        res_mask=temp(
+            bids(
+                root=root,
+                datatype="anat",
+                **inputs.subj_wildcards,
+                suffix="mask.nii.gz",
+                desc="f3d",
+                space="template",
+                hemi="{hemi}",
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -265,7 +269,7 @@ rule qc_nnunet_f3d:
 rule qc_nnunet_dice:
     input:
         res_mask=bids(
-            root=work,
+            root=root,
             datatype="anat",
             **inputs.subj_wildcards,
             suffix="mask.nii.gz",

--- a/hippunfold/workflow/rules/preproc_dsegtissue.smk
+++ b/hippunfold/workflow/rules/preproc_dsegtissue.smk
@@ -10,13 +10,15 @@ rule import_dseg_tissue:
         ),
         crop_cmd="-trim 5vox",  #leave 5 voxel padding
     output:
-        nii=bids(
-            root=work,
-            datatype="anat",
-            **inputs.subj_wildcards,
-            suffix="dseg.nii.gz",
-            space="corobl",
-            hemi="{hemi,L|R}",
+        nii=temp(
+            bids(
+                root=root,
+                datatype="anat",
+                **inputs.subj_wildcards,
+                suffix="dseg.nii.gz",
+                space="corobl",
+                hemi="{hemi,L|R}",
+            )
         ),
     container:
         config["singularity"]["autotop"]

--- a/hippunfold/workflow/rules/preproc_hippb500.smk
+++ b/hippunfold/workflow/rules/preproc_hippb500.smk
@@ -13,13 +13,15 @@ rule resample_hippdwi_to_template:
         bbox_x=lambda wildcards: config["hippdwi_opts"]["bbox_x"][wildcards.hemi],
         bbox_y=config["hippdwi_opts"]["bbox_y"],
     output:
-        crop_b500=bids(
-            root=work,
-            datatype="dwi",
-            hemi="{hemi,L|R}",
-            space="corobl",
-            suffix="b500.nii.gz",
-            **inputs.subj_wildcards,
+        crop_b500=temp(
+            bids(
+                root=root,
+                datatype="dwi",
+                hemi="{hemi,L|R}",
+                space="corobl",
+                suffix="b500.nii.gz",
+                **inputs.subj_wildcards,
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -40,7 +42,7 @@ rule resample_hippdwi_to_template:
 rule cp_b500_to_anat_dir:
     input:
         nii=bids(
-            root=work,
+            root=root,
             datatype="dwi",
             **inputs.subj_wildcards,
             suffix="b500.nii.gz",
@@ -48,14 +50,16 @@ rule cp_b500_to_anat_dir:
             hemi="{hemi}",
         ),
     output:
-        nii=bids(
-            root=work,
-            datatype="anat",
-            desc="preproc",
-            suffix="hippb500.nii.gz",
-            space="corobl",
-            hemi="{hemi}",
-            **inputs.subj_wildcards,
+        nii=temp(
+            bids(
+                root=root,
+                datatype="anat",
+                desc="preproc",
+                suffix="hippb500.nii.gz",
+                space="corobl",
+                hemi="{hemi}",
+                **inputs.subj_wildcards,
+            )
         ),
     group:
         "subj"

--- a/hippunfold/workflow/rules/preproc_t1.smk
+++ b/hippunfold/workflow/rules/preproc_t1.smk
@@ -5,7 +5,14 @@ rule import_t1:
     input:
         in_img=partial(get_single_bids_input, component="T1w"),
     output:
-        bids(root=work, datatype="anat", **inputs.subj_wildcards, suffix="T1w.nii.gz"),
+        temp(
+            bids(
+                root=root,
+                datatype="anat",
+                **inputs.subj_wildcards,
+                suffix="T1w.nii.gz",
+            )
+        ),
     group:
         "subj"
     shell:
@@ -35,7 +42,7 @@ else:
     rule n4_t1:
         input:
             t1=bids(
-                root=work,
+                root=root,
                 datatype="anat",
                 **inputs.subj_wildcards,
                 suffix="T1w.nii.gz",
@@ -71,7 +78,7 @@ rule warp_t1_to_corobl_crop:
             suffix="T1w.nii.gz",
         ),
         xfm=bids(
-            root=work,
+            root=root,
             datatype="warps",
             **inputs.subj_wildcards,
             suffix="xfm.txt",
@@ -87,14 +94,16 @@ rule warp_t1_to_corobl_crop:
             **wildcards, modality="T1w"
         ),
     output:
-        t1=bids(
-            root=work,
-            datatype="anat",
-            **inputs.subj_wildcards,
-            suffix="T1w.nii.gz",
-            space="corobl",
-            desc="preproc",
-            hemi="{hemi,L|R}",
+        t1=temp(
+            bids(
+                root=root,
+                datatype="anat",
+                **inputs.subj_wildcards,
+                suffix="T1w.nii.gz",
+                space="corobl",
+                desc="preproc",
+                hemi="{hemi,L|R}",
+            )
         ),
     container:
         config["singularity"]["autotop"]

--- a/hippunfold/workflow/rules/preproc_t2.smk
+++ b/hippunfold/workflow/rules/preproc_t2.smk
@@ -2,11 +2,13 @@ rule import_t2:
     input:
         inputs["T2w"].path,
     output:
-        bids(
-            root=work,
-            datatype="anat",
-            suffix="T2w.nii.gz",
-            **inputs["T2w"].wildcards,
+        temp(
+            bids(
+                root=root,
+                datatype="anat",
+                suffix="T2w.nii.gz",
+                **inputs["T2w"].wildcards,
+            )
         ),
     group:
         "subj"
@@ -17,18 +19,20 @@ rule import_t2:
 rule n4_t2:
     input:
         bids(
-            root=work,
+            root=root,
             datatype="anat",
             suffix="T2w.nii.gz",
             **inputs["T2w"].wildcards,
         ),
     output:
-        bids(
-            root=work,
-            datatype="anat",
-            desc="n4",
-            suffix="T2w.nii.gz",
-            **inputs["T2w"].wildcards,
+        temp(
+            bids(
+                root=root,
+                datatype="anat",
+                desc="n4",
+                suffix="T2w.nii.gz",
+                **inputs["T2w"].wildcards,
+            )
         ),
     threads: 8
     container:
@@ -49,7 +53,7 @@ def get_ref_n4_t2(wildcards):
         .filter(**wildcards)
         .expand(
             bids(
-                root=work,
+                root=root,
                 datatype="anat",
                 desc="n4",
                 suffix="T2w.nii.gz",
@@ -67,7 +71,7 @@ def get_floating_n4_t2(wildcards):
         .filter(**wildcards)
         .expand(
             bids(
-                root=work,
+                root=root,
                 datatype="anat",
                 suffix="T2w.nii.gz",
                 desc="n4",
@@ -84,7 +88,7 @@ rule reg_t2_to_ref:
         flo=get_floating_n4_t2,
     output:
         xfm_ras=bids(
-            root=work,
+            root=root,
             datatype="warps",
             **inputs.subj_wildcards,
             suffix="xfm.txt",
@@ -93,13 +97,15 @@ rule reg_t2_to_ref:
             desc="rigid",
             type_="ras",
         ),
-        warped=bids(
-            root=work,
-            datatype="anat",
-            suffix="T2w.nii.gz",
-            desc="aligned",
-            floating="{idx}",
-            **inputs.subj_wildcards,
+        warped=temp(
+            bids(
+                root=root,
+                datatype="anat",
+                suffix="T2w.nii.gz",
+                desc="aligned",
+                floating="{idx}",
+                **inputs.subj_wildcards,
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -114,7 +120,7 @@ rule reg_t2_to_ref:
 rule ras_to_itk_reg_t2:
     input:
         xfm_ras=bids(
-            root=work,
+            root=root,
             datatype="warps",
             **inputs.subj_wildcards,
             suffix="xfm.txt",
@@ -124,15 +130,17 @@ rule ras_to_itk_reg_t2:
             type_="ras",
         ),
     output:
-        xfm_itk=bids(
-            root=work,
-            datatype="warps",
-            **inputs.subj_wildcards,
-            suffix="xfm.txt",
-            from_="T2w{idx}",
-            to="T2w0",
-            desc="rigid",
-            type_="itk",
+        xfm_itk=temp(
+            bids(
+                root=root,
+                datatype="warps",
+                **inputs.subj_wildcards,
+                suffix="xfm.txt",
+                from_="T2w{idx}",
+                to="T2w0",
+                desc="rigid",
+                type_="itk",
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -154,7 +162,7 @@ def get_aligned_n4_t2(wildcards):
         .filter(**wildcards)
         .expand(
             bids(
-                root=work,
+                root=root,
                 datatype="anat",
                 desc="aligned",
                 floating="{idx}",
@@ -238,15 +246,17 @@ rule reg_t2_to_t1_part1:
             desc="preproc",
             space="T1w",
         ),
-        xfm_ras=bids(
-            root=work,
-            datatype="warps",
-            **inputs.subj_wildcards,
-            suffix="xfm.txt",
-            from_="T2w",
-            to="T1w",
-            desc="rigid",
-            type_="ras",
+        xfm_ras=temp(
+            bids(
+                root=root,
+                datatype="warps",
+                **inputs.subj_wildcards,
+                suffix="xfm.txt",
+                from_="T2w",
+                to="T1w",
+                desc="rigid",
+                type_="ras",
+            )
         ),
     log:
         bids(
@@ -271,7 +281,7 @@ rule reg_t2_to_t1_part1:
 rule reg_t2_to_t1_part2:
     input:
         xfm_ras=bids(
-            root=work,
+            root=root,
             datatype="warps",
             **inputs.subj_wildcards,
             suffix="xfm.txt",
@@ -281,15 +291,17 @@ rule reg_t2_to_t1_part2:
             type_="ras",
         ),
     output:
-        xfm_itk=bids(
-            root=work,
-            datatype="warps",
-            **inputs.subj_wildcards,
-            suffix="xfm.txt",
-            from_="T2w",
-            to="T1w",
-            desc="rigid",
-            type_="itk",
+        xfm_itk=temp(
+            bids(
+                root=root,
+                datatype="warps",
+                **inputs.subj_wildcards,
+                suffix="xfm.txt",
+                from_="T2w",
+                to="T1w",
+                desc="rigid",
+                type_="itk",
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -307,7 +319,7 @@ def get_inputs_compose_t2_xfm_corobl(wildcards):
         # xfm1: t1 to corobl
         t2_to_t1 = (
             bids(
-                root=work,
+                root=root,
                 datatype="warps",
                 **inputs.subj_wildcards,
                 suffix="xfm.txt",
@@ -319,7 +331,7 @@ def get_inputs_compose_t2_xfm_corobl(wildcards):
         )
         t1_to_cor = (
             bids(
-                root=work,
+                root=root,
                 datatype="warps",
                 **inputs.subj_wildcards,
                 suffix="xfm.txt",
@@ -335,7 +347,7 @@ def get_inputs_compose_t2_xfm_corobl(wildcards):
         # xfm0: t2 to template
         t2_to_std = (
             bids(
-                root=work,
+                root=root,
                 datatype="warps",
                 **inputs.subj_wildcards,
                 suffix="xfm.txt",
@@ -375,15 +387,17 @@ rule compose_t2_xfm_corobl:
     params:
         cmd=get_cmd_compose_t2_xfm_corobl,
     output:
-        t2_to_cor=bids(
-            root=work,
-            datatype="warps",
-            **inputs.subj_wildcards,
-            suffix="xfm.txt",
-            from_="T2w",
-            to="corobl",
-            desc="affine",
-            type_="itk",
+        t2_to_cor=temp(
+            bids(
+                root=root,
+                datatype="warps",
+                **inputs.subj_wildcards,
+                suffix="xfm.txt",
+                from_="T2w",
+                to="corobl",
+                desc="affine",
+                type_="itk",
+            )
         ),
     log:
         bids(
@@ -409,7 +423,7 @@ rule compose_t2_xfm_corobl:
 def get_xfm_to_corobl():
     if config["skip_coreg"]:
         xfm = bids(
-            root=work,
+            root=root,
             datatype="warps",
             **inputs.subj_wildcards,
             suffix="xfm.txt",
@@ -421,7 +435,7 @@ def get_xfm_to_corobl():
     else:
         xfm = (
             bids(
-                root=work,
+                root=root,
                 datatype="warps",
                 **inputs.subj_wildcards,
                 suffix="xfm.txt",
@@ -450,14 +464,16 @@ rule warp_t2_to_corobl_crop:
         ref=lambda wildcards, input: Path(input.template_dir)
         / config["template_files"][config["template"]]["crop_ref"].format(**wildcards),
     output:
-        nii=bids(
-            root=work,
-            datatype="anat",
-            **inputs.subj_wildcards,
-            suffix="T2w.nii.gz",
-            space="corobl",
-            desc="preproc",
-            hemi="{hemi,L|R}",
+        nii=temp(
+            bids(
+                root=root,
+                datatype="anat",
+                **inputs.subj_wildcards,
+                suffix="T2w.nii.gz",
+                space="corobl",
+                desc="preproc",
+                hemi="{hemi,L|R}",
+            )
         ),
     container:
         config["singularity"]["autotop"]

--- a/hippunfold/workflow/rules/qc.smk
+++ b/hippunfold/workflow/rules/qc.smk
@@ -1,7 +1,7 @@
 rule qc_reg_to_template:
     input:
         flo=bids(
-            root=work,
+            root=root,
             datatype="anat",
             **inputs.subj_wildcards,
             suffix="{native_modality}.nii.gz",
@@ -116,7 +116,7 @@ rule plot_subj_subfields:
 def get_bg_img_for_subfield_qc(wildcards):
     if config["modality"] == "hippb500":
         return bids(
-            root=work,
+            root=root,
             datatype="anat",
             desc="preproc",
             suffix="hippb500.nii.gz",
@@ -127,7 +127,7 @@ def get_bg_img_for_subfield_qc(wildcards):
     elif config["modality"] == "dsegtissue":
         # blank image as bg
         return bids(
-            root=work,
+            root=root,
             datatype="warps",
             suffix="cropref.nii.gz",
             space="{space}",

--- a/hippunfold/workflow/rules/resample_final_to_crop_native.smk
+++ b/hippunfold/workflow/rules/resample_final_to_crop_native.smk
@@ -21,13 +21,15 @@ rule create_native_crop_ref:
         resample=config["crop_native_res"],
         pad_to=config["crop_native_box"],
     output:
-        ref=bids(
-            root=work,
-            datatype="warps",
-            suffix="cropref.nii.gz",
-            space="{native_modality}",
-            hemi="{hemi}",
-            **inputs.subj_wildcards,
+        ref=temp(
+            bids(
+                root=root,
+                datatype="warps",
+                suffix="cropref.nii.gz",
+                space="{native_modality}",
+                hemi="{hemi}",
+                **inputs.subj_wildcards,
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -42,7 +44,7 @@ rule create_native_crop_ref:
 rule resample_unet_native_crop:
     input:
         nii=bids(
-            root=work,
+            root=root,
             datatype="anat",
             **inputs.subj_wildcards,
             suffix="dseg.nii.gz",
@@ -51,7 +53,7 @@ rule resample_unet_native_crop:
             hemi="{hemi}",
         ),
         xfm=bids(
-            root=work,
+            root=root,
             datatype="warps",
             **inputs.subj_wildcards,
             suffix="xfm.txt",
@@ -61,7 +63,7 @@ rule resample_unet_native_crop:
             type_="itk",
         ),
         ref=bids(
-            root=work,
+            root=root,
             datatype="warps",
             suffix="cropref.nii.gz",
             space="{native_modality}",
@@ -69,14 +71,16 @@ rule resample_unet_native_crop:
             **inputs.subj_wildcards,
         ),
     output:
-        nii=bids(
-            root=work,
-            datatype="anat",
-            suffix="dseg.nii.gz",
-            desc="unet",
-            space="crop{native_modality}",
-            hemi="{hemi}",
-            **inputs.subj_wildcards,
+        nii=temp(
+            bids(
+                root=root,
+                datatype="anat",
+                suffix="dseg.nii.gz",
+                desc="unet",
+                space="crop{native_modality}",
+                hemi="{hemi}",
+                **inputs.subj_wildcards,
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -92,7 +96,7 @@ rule resample_unet_native_crop:
 rule resample_postproc_native_crop:
     input:
         nii=bids(
-            root=work,
+            root=root,
             datatype="anat",
             **inputs.subj_wildcards,
             suffix="dseg.nii.gz",
@@ -102,7 +106,7 @@ rule resample_postproc_native_crop:
             label=config["autotop_labels"][-1],
         ),
         xfm=bids(
-            root=work,
+            root=root,
             datatype="warps",
             **inputs.subj_wildcards,
             suffix="xfm.txt",
@@ -112,7 +116,7 @@ rule resample_postproc_native_crop:
             type_="itk",
         ),
         ref=bids(
-            root=work,
+            root=root,
             datatype="warps",
             suffix="cropref.nii.gz",
             space="{native_modality}",
@@ -120,14 +124,16 @@ rule resample_postproc_native_crop:
             **inputs.subj_wildcards,
         ),
     output:
-        nii=bids(
-            root=work,
-            datatype="anat",
-            suffix="dseg.nii.gz",
-            desc="postproc",
-            space="crop{native_modality}",
-            hemi="{hemi}",
-            **inputs.subj_wildcards,
+        nii=temp(
+            bids(
+                root=root,
+                datatype="anat",
+                suffix="dseg.nii.gz",
+                desc="postproc",
+                space="crop{native_modality}",
+                hemi="{hemi}",
+                **inputs.subj_wildcards,
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -143,7 +149,7 @@ rule resample_postproc_native_crop:
 rule resample_subfields_native_crop:
     input:
         nii=bids(
-            root=work,
+            root=root,
             datatype="anat",
             desc="subfields",
             suffix="dseg.nii.gz",
@@ -154,7 +160,7 @@ rule resample_subfields_native_crop:
             **inputs.subj_wildcards,
         ),
         xfm=bids(
-            root=work,
+            root=root,
             datatype="warps",
             **inputs.subj_wildcards,
             suffix="xfm.txt",
@@ -164,7 +170,7 @@ rule resample_subfields_native_crop:
             type_="itk",
         ),
         ref=bids(
-            root=work,
+            root=root,
             datatype="warps",
             suffix="cropref.nii.gz",
             space="{native_modality}",
@@ -197,7 +203,7 @@ rule resample_subfields_native_crop:
 rule resample_coords_native_crop:
     input:
         nii=bids(
-            root=work,
+            root=root,
             datatype="coords",
             dir="{dir}",
             label="{label}",
@@ -208,7 +214,7 @@ rule resample_coords_native_crop:
             **inputs.subj_wildcards,
         ),
         xfm=bids(
-            root=work,
+            root=root,
             datatype="warps",
             **inputs.subj_wildcards,
             suffix="xfm.txt",
@@ -218,7 +224,7 @@ rule resample_coords_native_crop:
             type_="itk",
         ),
         ref=bids(
-            root=work,
+            root=root,
             datatype="warps",
             suffix="cropref.nii.gz",
             space="{native_modality}",
@@ -258,7 +264,7 @@ rule resample_native_to_crop:
             suffix="{native_modality}.nii.gz",
         ),
         ref=bids(
-            root=work,
+            root=root,
             datatype="warps",
             suffix="cropref.nii.gz",
             space="{native_modality}",
@@ -291,7 +297,7 @@ def get_xfm_t2_to_t1():
         xfm = []
     else:
         xfm = bids(
-            root=work,
+            root=root,
             datatype="warps",
             **inputs.subj_wildcards,
             suffix="xfm.txt",
@@ -313,7 +319,7 @@ rule resample_t2_to_crop:
             desc="preproc",
         ),
         ref=bids(
-            root=work,
+            root=root,
             datatype="warps",
             suffix="cropref.nii.gz",
             space="{native_modality}",

--- a/hippunfold/workflow/rules/shape_inject.smk
+++ b/hippunfold/workflow/rules/shape_inject.smk
@@ -5,7 +5,7 @@
 def get_input_splitseg_for_shape_inject(wildcards):
     if config["modality"] == "dsegtissue":
         seg = bids(
-            root=work,
+            root=root,
             datatype="anat",
             **inputs.subj_wildcards,
             suffix="dsegsplit",
@@ -14,7 +14,7 @@ def get_input_splitseg_for_shape_inject(wildcards):
         ).format(**wildcards)
     else:
         seg = bids(
-            root=work,
+            root=root,
             datatype="anat",
             **inputs.subj_wildcards,
             suffix="dsegsplit",
@@ -92,7 +92,7 @@ def get_inject_scaling_opt(wildcards):
 rule resample_template_dseg_tissue_for_reg:
     input:
         template_seg=bids(
-            root=work,
+            root=root,
             datatype="anat",
             space="template",
             **inputs.subj_wildcards,
@@ -106,14 +106,16 @@ rule resample_template_dseg_tissue_for_reg:
         ),
         crop_cmd="-trim 5vox",  #leave 5 voxel padding
     output:
-        template_seg=bids(
-            root=work,
-            datatype="anat",
-            space="template",
-            **inputs.subj_wildcards,
-            desc="hipptissueresampled",
-            hemi="{hemi}",
-            suffix="dseg.nii.gz",
+        template_seg=temp(
+            bids(
+                root=root,
+                datatype="anat",
+                space="template",
+                **inputs.subj_wildcards,
+                desc="hipptissueresampled",
+                hemi="{hemi}",
+                suffix="dseg.nii.gz",
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -128,7 +130,7 @@ rule resample_template_dseg_tissue_for_reg:
 rule template_shape_reg:
     input:
         template_seg=bids(
-            root=work,
+            root=root,
             datatype="anat",
             space="template",
             **inputs.subj_wildcards,
@@ -144,7 +146,7 @@ rule template_shape_reg:
         img_pairs=get_image_pairs,
     output:
         matrix=bids(
-            root=work,
+            root=root,
             **inputs.subj_wildcards,
             suffix="xfm.txt",
             datatype="warps",
@@ -155,16 +157,18 @@ rule template_shape_reg:
             type_="ras",
             hemi="{hemi}",
         ),
-        warp=bids(
-            root=work,
-            **inputs.subj_wildcards,
-            suffix="xfm.nii.gz",
-            datatype="warps",
-            desc="greedy",
-            from_="template",
-            to="subject",
-            space="corobl",
-            hemi="{hemi}",
+        warp=temp(
+            bids(
+                root=root,
+                **inputs.subj_wildcards,
+                suffix="xfm.nii.gz",
+                datatype="warps",
+                desc="greedy",
+                from_="template",
+                to="subject",
+                space="corobl",
+                hemi="{hemi}",
+            )
         ),
     group:
         "subj"
@@ -191,7 +195,7 @@ rule dilate_dentate_pd_src_sink:
     as they are very small. This dilates them into relative background labels"""
     input:
         template_seg=bids(
-            root=work,
+            root=root,
             datatype="anat",
             space="template",
             **inputs.subj_wildcards,
@@ -206,14 +210,16 @@ rule dilate_dentate_pd_src_sink:
         sink_bg=10,
         struc_elem_size=3,
     output:
-        template_seg=bids(
-            root=work,
-            datatype="anat",
-            space="template",
-            **inputs.subj_wildcards,
-            desc="hipptissuedilated",
-            hemi="{hemi}",
-            suffix="dseg.nii.gz",
+        template_seg=temp(
+            bids(
+                root=root,
+                datatype="anat",
+                space="template",
+                **inputs.subj_wildcards,
+                desc="hipptissuedilated",
+                hemi="{hemi}",
+                suffix="dseg.nii.gz",
+            )
         ),
     group:
         "subj"
@@ -228,7 +234,7 @@ rule dilate_dentate_pd_src_sink:
 rule template_shape_inject:
     input:
         template_seg=bids(
-            root=work,
+            root=root,
             datatype="anat",
             space="template",
             **inputs.subj_wildcards,
@@ -237,7 +243,7 @@ rule template_shape_inject:
             suffix="dseg.nii.gz",
         ),
         upsampled_ref=bids(
-            root=work,
+            root=root,
             datatype="anat",
             **inputs.subj_wildcards,
             suffix="ref.nii.gz",
@@ -247,7 +253,7 @@ rule template_shape_inject:
             hemi="{hemi}",
         ),
         matrix=bids(
-            root=work,
+            root=root,
             **inputs.subj_wildcards,
             suffix="xfm.txt",
             datatype="warps",
@@ -259,7 +265,7 @@ rule template_shape_inject:
             hemi="{hemi}",
         ),
         warp=bids(
-            root=work,
+            root=root,
             **inputs.subj_wildcards,
             suffix="xfm.nii.gz",
             datatype="warps",
@@ -272,15 +278,17 @@ rule template_shape_inject:
     params:
         interp_opt="-ri LABEL 0.1mm",  # smoothing sigma = 100micron
     output:
-        inject_seg=bids(
-            root=work,
-            datatype="anat",
-            **inputs.subj_wildcards,
-            suffix="dseg.nii.gz",
-            desc="inject",
-            space="corobl",
-            hemi="{hemi}",
-            label="{label}",
+        inject_seg=temp(
+            bids(
+                root=root,
+                datatype="anat",
+                **inputs.subj_wildcards,
+                suffix="dseg.nii.gz",
+                desc="inject",
+                space="corobl",
+                hemi="{hemi}",
+                label="{label}",
+            )
         ),
     log:
         bids(
@@ -305,7 +313,7 @@ rule inject_init_laplace_coords:
     """ TODO: this may not be needed anymore """
     input:
         upsampled_ref=bids(
-            root=work,
+            root=root,
             datatype="anat",
             **inputs.subj_wildcards,
             suffix="ref.nii.gz",
@@ -315,7 +323,7 @@ rule inject_init_laplace_coords:
             label="{label}",
         ),
         matrix=bids(
-            root=work,
+            root=root,
             **inputs.subj_wildcards,
             suffix="xfm.txt",
             datatype="warps",
@@ -327,7 +335,7 @@ rule inject_init_laplace_coords:
             hemi="{hemi}",
         ),
         warp=bids(
-            root=work,
+            root=root,
             **inputs.subj_wildcards,
             suffix="xfm.nii.gz",
             datatype="warps",
@@ -338,7 +346,7 @@ rule inject_init_laplace_coords:
             hemi="{hemi}",
         ),
         coords=bids(
-            root=work,
+            root=root,
             datatype="coords",
             **inputs.subj_wildcards,
             dir="{dir}",
@@ -351,16 +359,18 @@ rule inject_init_laplace_coords:
     params:
         interp_opt="-ri LIN",
     output:
-        init_coords=bids(
-            root=work,
-            datatype="coords",
-            **inputs.subj_wildcards,
-            dir="{dir}",
-            label="{label}",
-            suffix="coords.nii.gz",
-            desc="init",
-            space="corobl",
-            hemi="{hemi}",
+        init_coords=temp(
+            bids(
+                root=root,
+                datatype="coords",
+                **inputs.subj_wildcards,
+                dir="{dir}",
+                label="{label}",
+                suffix="coords.nii.gz",
+                desc="init",
+                space="corobl",
+                hemi="{hemi}",
+            )
         ),
     log:
         bids(
@@ -391,7 +401,7 @@ rule reinsert_subject_labels:
                 4) and add this to retained labels"""
     input:
         inject_seg=bids(
-            root=work,
+            root=root,
             datatype="anat",
             **inputs.subj_wildcards,
             suffix="dseg.nii.gz",
@@ -406,15 +416,17 @@ rule reinsert_subject_labels:
             str(label) for label in config["shape_inject"]["labels_reinsert"]
         ),
     output:
-        postproc_seg=bids(
-            root=work,
-            datatype="anat",
-            **inputs.subj_wildcards,
-            suffix="dseg.nii.gz",
-            desc="postproc",
-            space="corobl",
-            hemi="{hemi}",
-            label="{label}",
+        postproc_seg=temp(
+            bids(
+                root=root,
+                datatype="anat",
+                **inputs.subj_wildcards,
+                suffix="dseg.nii.gz",
+                desc="postproc",
+                space="corobl",
+                hemi="{hemi}",
+                label="{label}",
+            )
         ),
     group:
         "subj"

--- a/hippunfold/workflow/rules/subfields.smk
+++ b/hippunfold/workflow/rules/subfields.smk
@@ -4,14 +4,16 @@ rule import_dseg_subfields:
         vol_dseg=partial(get_single_bids_input, component="dsegsubfields"),
         label_list=Path(workflow.basedir) / "../resources/atlas-v2/labellist_withdg.txt",
     output:
-        label_dseg=bids(
-            root=work,
-            datatype="anat",
-            **inputs.subj_wildcards,
-            desc="subfields",
-            suffix="dseg.nii.gz",
-            space="corobl",
-            hemi="{hemi,L|R}",
+        label_dseg=temp(
+            bids(
+                root=root,
+                datatype="anat",
+                **inputs.subj_wildcards,
+                desc="subfields",
+                suffix="dseg.nii.gz",
+                space="corobl",
+                hemi="{hemi,L|R}",
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -26,7 +28,7 @@ rule import_dseg_subfields:
 rule subfields_to_label_gifti:
     input:
         vol=bids(
-            root=work,
+            root=root,
             datatype="anat",
             **inputs.subj_wildcards,
             desc="subfields",
@@ -35,7 +37,7 @@ rule subfields_to_label_gifti:
             hemi="{hemi}",
         ),
         surf_gii=bids(
-            root=work,
+            root=root,
             datatype="surf",
             suffix="midthickness.surf.gii",
             space="corobl",
@@ -101,7 +103,7 @@ rule native_label_gii_to_unfold_nii:
             **inputs.subj_wildcards,
         ),
         ref_nii=bids(
-            root=work,
+            root=root,
             datatype="anat",
             suffix="refvol.nii.gz",
             space="unfold",
@@ -113,14 +115,16 @@ rule native_label_gii_to_unfold_nii:
     params:
         interp="-nearest-vertex 0.3",
     output:
-        label_nii=bids(
-            root=work,
-            datatype="anat",
-            suffix="subfields.nii.gz",
-            space="unfold",
-            hemi="{hemi}",
-            label="{label}",
-            **inputs.subj_wildcards,
+        label_nii=temp(
+            bids(
+                root=root,
+                datatype="anat",
+                suffix="subfields.nii.gz",
+                space="unfold",
+                hemi="{hemi}",
+                label="{label}",
+                **inputs.subj_wildcards,
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -174,16 +178,18 @@ rule label_subfields_from_vol_coords_corobl:
             **inputs.subj_wildcards,
         ),
     output:
-        nii_label=bids(
-            root=work,
-            datatype="anat",
-            desc="subfieldsnotissue",
-            suffix="dseg.nii.gz",
-            space="corobl",
-            hemi="{hemi}",
-            atlas="{atlas}",
-            label="{label,hipp}",
-            **inputs.subj_wildcards,
+        nii_label=temp(
+            bids(
+                root=root,
+                datatype="anat",
+                desc="subfieldsnotissue",
+                suffix="dseg.nii.gz",
+                space="corobl",
+                hemi="{hemi}",
+                atlas="{atlas}",
+                label="{label,hipp}",
+                **inputs.subj_wildcards,
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -221,7 +227,7 @@ rule combine_tissue_subfield_labels_corobl:
     input:
         tissue=get_labels_for_laplace,
         subfields=bids(
-            root=work,
+            root=root,
             datatype="anat",
             desc="subfieldsnotissue",
             suffix="dseg.nii.gz",
@@ -234,16 +240,18 @@ rule combine_tissue_subfield_labels_corobl:
     params:
         remap=get_tissue_atlas_remapping,
     output:
-        combined=bids(
-            root=work,
-            datatype="anat",
-            desc="subfields",
-            suffix="dseg.nii.gz",
-            space="corobl",
-            hemi="{hemi}",
-            label="{label,hipp}",
-            atlas="{atlas}",
-            **inputs.subj_wildcards,
+        combined=temp(
+            bids(
+                root=root,
+                datatype="anat",
+                desc="subfields",
+                suffix="dseg.nii.gz",
+                space="corobl",
+                hemi="{hemi}",
+                label="{label,hipp}",
+                atlas="{atlas}",
+                **inputs.subj_wildcards,
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -259,7 +267,7 @@ rule resample_subfields_to_native:
     """Resampling to native space"""
     input:
         nii=bids(
-            root=work,
+            root=root,
             datatype="anat",
             desc="subfields",
             suffix="dseg.nii.gz",
@@ -270,7 +278,7 @@ rule resample_subfields_to_native:
             **inputs.subj_wildcards,
         ),
         xfm=bids(
-            root=work,
+            root=root,
             datatype="warps",
             **inputs.subj_wildcards,
             suffix="xfm.txt",
@@ -313,7 +321,7 @@ rule resample_postproc_to_native:
     """Resample post-processed tissue seg to native"""
     input:
         nii=bids(
-            root=work,
+            root=root,
             datatype="anat",
             **inputs.subj_wildcards,
             suffix="dseg.nii.gz",
@@ -323,7 +331,7 @@ rule resample_postproc_to_native:
             label=config["autotop_labels"][-1],
         ),
         xfm=bids(
-            root=work,
+            root=root,
             datatype="warps",
             **inputs.subj_wildcards,
             suffix="xfm.txt",
@@ -340,14 +348,16 @@ rule resample_postproc_to_native:
             suffix="{native_modality}.nii.gz",
         ),
     output:
-        nii=bids(
-            root=work,
-            datatype="anat",
-            suffix="dseg.nii.gz",
-            desc="postproc",
-            space="{native_modality,T2w|T2w}",
-            hemi="{hemi}",
-            **inputs.subj_wildcards,
+        nii=temp(
+            bids(
+                root=root,
+                datatype="anat",
+                suffix="dseg.nii.gz",
+                desc="postproc",
+                space="{native_modality,T2w|T2w}",
+                hemi="{hemi}",
+                **inputs.subj_wildcards,
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -364,7 +374,7 @@ rule resample_unet_to_native:
     """Resample unet tissue seg to native"""
     input:
         nii=bids(
-            root=work,
+            root=root,
             datatype="anat",
             **inputs.subj_wildcards,
             suffix="dseg.nii.gz",
@@ -373,7 +383,7 @@ rule resample_unet_to_native:
             hemi="{hemi}",
         ),
         xfm=bids(
-            root=work,
+            root=root,
             datatype="warps",
             **inputs.subj_wildcards,
             suffix="xfm.txt",
@@ -390,14 +400,16 @@ rule resample_unet_to_native:
             suffix="{native_modality}.nii.gz",
         ),
     output:
-        nii=bids(
-            root=work,
-            datatype="anat",
-            suffix="dseg.nii.gz",
-            desc="unet",
-            space="{native_modality,T1w|T2w}",
-            hemi="{hemi}",
-            **inputs.subj_wildcards,
+        nii=temp(
+            bids(
+                root=root,
+                datatype="anat",
+                suffix="dseg.nii.gz",
+                desc="unet",
+                space="{native_modality,T1w|T2w}",
+                hemi="{hemi}",
+                **inputs.subj_wildcards,
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -414,7 +426,7 @@ rule resample_subfields_to_unfold:
     """Resampling to unfold space"""
     input:
         nii=bids(
-            root=work,
+            root=root,
             datatype="anat",
             desc="subfields",
             suffix="dseg.nii.gz",
@@ -424,7 +436,7 @@ rule resample_subfields_to_unfold:
             **inputs.subj_wildcards,
         ),
         xfm=bids(
-            root=work,
+            root=root,
             datatype="warps",
             **inputs.subj_wildcards,
             suffix="xfm.nii.gz",

--- a/hippunfold/workflow/rules/templateseg.smk
+++ b/hippunfold/workflow/rules/templateseg.smk
@@ -10,7 +10,7 @@ def get_smoothing_opt(wildcards):
 rule template_reg:
     input:
         fixed_img=bids(
-            root=work,
+            root=root,
             datatype="anat",
             **inputs.subj_wildcards,
             suffix="{modality}.nii.gz".format(
@@ -21,7 +21,7 @@ rule template_reg:
             hemi="{hemi}",
         ),
         moving_img=bids(
-            root=work,
+            root=root,
             datatype="anat",
             suffix="{modality}.nii.gz".format(
                 modality=get_modality_suffix(config["modality"])
@@ -40,16 +40,18 @@ rule template_reg:
         smoothing_opts=get_smoothing_opt,
         iteration_opts="-n 100x50x10",  #default -n 100x100
     output:
-        warp=bids(
-            root=work,
-            **inputs.subj_wildcards,
-            suffix="xfm.nii.gz",
-            datatype="warps",
-            desc="greedytemplatereg",
-            from_="template",
-            to="subject",
-            space="corobl",
-            hemi="{hemi}",
+        warp=temp(
+            bids(
+                root=root,
+                **inputs.subj_wildcards,
+                suffix="xfm.nii.gz",
+                datatype="warps",
+                desc="greedytemplatereg",
+                from_="template",
+                to="subject",
+                space="corobl",
+                hemi="{hemi}",
+            )
         ),
     group:
         "subj"
@@ -67,7 +69,7 @@ rule template_reg:
 rule warp_template_dseg:
     input:
         upsampled_ref=bids(
-            root=work,
+            root=root,
             datatype="anat",
             **inputs.subj_wildcards,
             suffix="ref.nii.gz",
@@ -77,7 +79,7 @@ rule warp_template_dseg:
             label="{label}",
         ),
         warp=bids(
-            root=work,
+            root=root,
             **inputs.subj_wildcards,
             suffix="xfm.nii.gz",
             datatype="warps",
@@ -88,7 +90,7 @@ rule warp_template_dseg:
             hemi="{hemi}",
         ),
         template_dseg=bids(
-            root=work,
+            root=root,
             datatype="anat",
             suffix="dseg.nii.gz",
             desc="hipptissue",
@@ -99,15 +101,17 @@ rule warp_template_dseg:
     params:
         interp_opt="-ri LABEL 0.2vox",
     output:
-        inject_seg=bids(
-            root=work,
-            datatype="anat",
-            **inputs.subj_wildcards,
-            suffix="dseg.nii.gz",
-            desc="postproc",
-            space="corobl",
-            hemi="{hemi}",
-            label="{label}",
+        inject_seg=temp(
+            bids(
+                root=root,
+                datatype="anat",
+                **inputs.subj_wildcards,
+                suffix="dseg.nii.gz",
+                desc="postproc",
+                space="corobl",
+                hemi="{hemi}",
+                label="{label}",
+            )
         ),
     group:
         "subj"
@@ -124,7 +128,7 @@ rule warp_template_coords:
     input:
         template_dir=Path(download_dir) / "template" / config["template"],
         ref=bids(
-            root=work,
+            root=root,
             datatype="anat",
             **inputs.subj_wildcards,
             suffix=f"{config['modality']}.nii.gz",
@@ -133,7 +137,7 @@ rule warp_template_coords:
             hemi="{hemi}",
         ),
         warp=bids(
-            root=work,
+            root=root,
             **inputs.subj_wildcards,
             suffix="xfm.nii.gz",
             datatype="warps",
@@ -144,7 +148,7 @@ rule warp_template_coords:
             hemi="{hemi}",
         ),
         template_coords=bids(
-            root=work,
+            root=root,
             datatype="coords",
             **inputs.subj_wildcards,
             dir="{dir}",
@@ -157,16 +161,18 @@ rule warp_template_coords:
     params:
         interp_opt="-ri NN",
     output:
-        init_coords=bids(
-            root=work,
-            datatype="coords",
-            **inputs.subj_wildcards,
-            dir="{dir}",
-            label="{label}",
-            suffix="coords.nii.gz",
-            desc="init",
-            space="corobl",
-            hemi="{hemi}",
+        init_coords=temp(
+            bids(
+                root=root,
+                datatype="coords",
+                **inputs.subj_wildcards,
+                dir="{dir}",
+                label="{label}",
+                suffix="coords.nii.gz",
+                desc="init",
+                space="corobl",
+                hemi="{hemi}",
+            )
         ),
     group:
         "subj"
@@ -182,7 +188,7 @@ rule warp_template_coords:
 rule warp_template_anat:
     input:
         ref=bids(
-            root=work,
+            root=root,
             datatype="anat",
             **inputs.subj_wildcards,
             suffix=f"{config['modality']}.nii.gz",
@@ -191,7 +197,7 @@ rule warp_template_anat:
             hemi="{hemi}",
         ),
         warp=bids(
-            root=work,
+            root=root,
             **inputs.subj_wildcards,
             suffix="xfm.nii.gz",
             datatype="warps",
@@ -202,7 +208,7 @@ rule warp_template_anat:
             hemi="{hemi}",
         ),
         template_anat=bids(
-            root=work,
+            root=root,
             datatype="anat",
             suffix="{modality}.nii.gz".format(
                 modality=get_modality_suffix(config["modality"])
@@ -217,14 +223,16 @@ rule warp_template_anat:
             **wildcards
         ),
     output:
-        warped=bids(
-            root=work,
-            datatype="anat",
-            **inputs.subj_wildcards,
-            suffix=f"{config['modality']}.nii.gz",
-            desc="warpedtemplate",
-            space="corobl",
-            hemi="{hemi}",
+        warped=temp(
+            bids(
+                root=root,
+                datatype="anat",
+                **inputs.subj_wildcards,
+                suffix=f"{config['modality']}.nii.gz",
+                desc="warpedtemplate",
+                space="corobl",
+                hemi="{hemi}",
+            )
         ),
     group:
         "subj"

--- a/hippunfold/workflow/rules/warps.smk
+++ b/hippunfold/workflow/rules/warps.smk
@@ -29,23 +29,27 @@ rule reg_to_template:
     params:
         cmd=reg_to_template_cmd,
     output:
-        warped_subj=bids(
-            root=work,
-            datatype="anat",
-            **inputs.subj_wildcards,
-            suffix="{modality,T1w|T2w}.nii.gz",
-            space=config["template"],
-            desc="affine",
+        warped_subj=temp(
+            bids(
+                root=root,
+                datatype="anat",
+                **inputs.subj_wildcards,
+                suffix="{modality,T1w|T2w}.nii.gz",
+                space=config["template"],
+                desc="affine",
+            )
         ),
-        xfm_ras=bids(
-            root=work,
-            datatype="warps",
-            **inputs.subj_wildcards,
-            suffix="xfm.txt",
-            from_="{modality,T1w|T2w}",
-            to=config["template"],
-            desc="affine",
-            type_="ras",
+        xfm_ras=temp(
+            bids(
+                root=root,
+                datatype="warps",
+                **inputs.subj_wildcards,
+                suffix="xfm.txt",
+                from_="{modality,T1w|T2w}",
+                to=config["template"],
+                desc="affine",
+                type_="ras",
+            )
         ),
     log:
         bids(
@@ -70,7 +74,7 @@ rule reg_to_template:
 rule convert_template_xfm_ras2itk:
     input:
         bids(
-            root=work,
+            root=root,
             datatype="warps",
             **inputs.subj_wildcards,
             suffix="xfm.txt",
@@ -80,15 +84,17 @@ rule convert_template_xfm_ras2itk:
             type_="ras",
         ),
     output:
-        bids(
-            root=work,
-            datatype="warps",
-            **inputs.subj_wildcards,
-            suffix="xfm.txt",
-            from_="{reg_suffix}",
-            to=config["template"],
-            desc="affine",
-            type_="itk",
+        temp(
+            bids(
+                root=root,
+                datatype="warps",
+                **inputs.subj_wildcards,
+                suffix="xfm.txt",
+                from_="{reg_suffix}",
+                to=config["template"],
+                desc="affine",
+                type_="itk",
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -104,7 +110,7 @@ rule convert_template_xfm_ras2itk:
 rule compose_template_xfm_corobl:
     input:
         sub_to_std=bids(
-            root=work,
+            root=root,
             datatype="warps",
             **inputs.subj_wildcards,
             suffix="xfm.txt",
@@ -120,15 +126,17 @@ rule compose_template_xfm_corobl:
             **wildcards
         ),
     output:
-        sub_to_cor=bids(
-            root=work,
-            datatype="warps",
-            **inputs.subj_wildcards,
-            suffix="xfm.txt",
-            from_="T1w",
-            to="corobl",
-            desc="affine",
-            type_="itk",
+        sub_to_cor=temp(
+            bids(
+                root=root,
+                datatype="warps",
+                **inputs.subj_wildcards,
+                suffix="xfm.txt",
+                from_="T1w",
+                to="corobl",
+                desc="affine",
+                type_="itk",
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -143,7 +151,7 @@ rule compose_template_xfm_corobl:
 rule invert_template_xfm_itk2ras:
     input:
         xfm_ras=bids(
-            root=work,
+            root=root,
             datatype="warps",
             **inputs.subj_wildcards,
             suffix="xfm.txt",
@@ -153,15 +161,17 @@ rule invert_template_xfm_itk2ras:
             type_="itk",
         ),
     output:
-        xfm_ras=bids(
-            root=work,
-            datatype="warps",
-            **inputs.subj_wildcards,
-            suffix="xfm.txt",
-            from_="T1w",
-            to="corobl",
-            desc="affineInverse",
-            type_="ras",
+        xfm_ras=temp(
+            bids(
+                root=root,
+                datatype="warps",
+                **inputs.subj_wildcards,
+                suffix="xfm.txt",
+                from_="T1w",
+                to="corobl",
+                desc="affineInverse",
+                type_="ras",
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -176,7 +186,7 @@ rule invert_template_xfm_itk2ras:
 rule template_xfm_itk2ras:
     input:
         xfm_ras=bids(
-            root=work,
+            root=root,
             datatype="warps",
             **inputs.subj_wildcards,
             suffix="xfm.txt",
@@ -186,15 +196,17 @@ rule template_xfm_itk2ras:
             type_="itk",
         ),
     output:
-        xfm_ras=bids(
-            root=work,
-            datatype="warps",
-            **inputs.subj_wildcards,
-            suffix="xfm.txt",
-            from_="{native_modality,T1w|T2w}",
-            to="corobl",
-            desc="affine",
-            type_="ras",
+        xfm_ras=temp(
+            bids(
+                root=root,
+                datatype="warps",
+                **inputs.subj_wildcards,
+                suffix="xfm.txt",
+                from_="{native_modality,T1w|T2w}",
+                to="corobl",
+                desc="affine",
+                type_="ras",
+            )
         ),
     container:
         config["singularity"]["autotop"]
@@ -220,13 +232,15 @@ rule create_unfold_ref:
         ),
         orient=lambda wildcards: config["unfold_vol_ref"][wildcards.label]["orient"],
     output:
-        nii=bids(
-            root=work,
-            space="unfold",
-            label="{label}",
-            datatype="warps",
-            suffix="refvol.nii.gz",
-            **inputs.subj_wildcards,
+        nii=temp(
+            bids(
+                root=root,
+                space="unfold",
+                label="{label}",
+                datatype="warps",
+                suffix="refvol.nii.gz",
+                **inputs.subj_wildcards,
+            )
         ),
     group:
         "subj"


### PR DESCRIPTION
Taking advantage of the fact that we have very few open workflow PRs to do some of the clean-up PRs. 

Use root for everything, and use temp(...) for any outputs that were put in work.

Anything that was in work will now just be put in the main output location, and deleted when no longer needed, unless `--notemp` is used.

This makes the workflow simpler and less error prone since we don't have to remember which files are in work and which are in root (all are in root), and also much easier to set a file as temporary, since we now only need to specify it when it is declared as an output, by putting `temp(...)` around it. 

Note: I haven't changed which files are put into work (now temp())  in this PR, just kept things as they were, can do that in further clean-up/output-refactoring PRs.. 