### PR TITLE
removed unfold spring and unfold smooth

### DIFF
--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -616,7 +616,7 @@ laminar_coords_res:
   dentate: 0.1x0.1x0.1mm
 
 resample_dseg_for_templatereg: 0.3x0.3x0.3mm
-unfoldreg_padding: 64x64x0vox
+unfoldreg_padding: 0x0x0vox
 
 density: #temporary var
   hipp: 

--- a/hippunfold/plugins/atlas.py
+++ b/hippunfold/plugins/atlas.py
@@ -18,7 +18,7 @@ import json
 import os
 
 # Global variable to store the commit hash
-ATLAS_REPO_COMMIT = "7c292113c669a629773a644f82485ffde1842f52"
+ATLAS_REPO_COMMIT = "c1a53ecade939ead9de8f9169c6a4ddff0c73c3d"
 
 
 def get_download_dir():
@@ -173,18 +173,16 @@ class AtlasConfig(PluginBase):
         )
         self.try_add_argument(
             group,
-            "--density",
-            "--density",
+            "--output-density",
+            "--output_density",
             action="store",
             type=str,
-            dest="density",
-            default=[
-                "hipp=21k",
-                "dentate=3k",
-            ],
+            dest="output_density",
+            default=["12k"],
+            choices=["1k", "5k", "12k"],
             nargs="+",
             help=(
-                "Density for surface meshes. Use --atlas-list-density to get a listing of available densities (default: %(default)s)"
+                "Sets the output vertex density for results, using the same vertex density for hipp and dentate (default: %(default)s)"
             ),
         )
 
@@ -193,6 +191,7 @@ class AtlasConfig(PluginBase):
         """Add atlas to config."""
         atlas = self.pop(namespace, "atlas")
         new_atlas_name = self.pop(namespace, "new_atlas_name")
+        output_density = self.pop(namespace, "output_density")
 
         if (
             namespace["analysis_level"] == "group_create_atlas"
@@ -205,25 +204,4 @@ class AtlasConfig(PluginBase):
         config["atlas"] = atlas
         config["new_atlas_name"] = new_atlas_name
         config["atlas_metadata"] = self.atlas_config
-
-        # parsing for density
-        density_args = self.pop(namespace, "density")
-
-        density = {}
-        for d_arg in density_args:
-            if "=" not in d_arg:
-                raise argparse.ArgumentTypeError(
-                    f"Invalid format: '{item}'. Expected format label=density1,density2,..."
-                )
-
-            label, values = d_arg.split("=", 1)
-            if label not in ["hipp", "dentate"]:
-                raise argparse.ArgumentTypeError(
-                    f"Invalid label: '{label}'. Valid labels are hipp or dentate"
-                )
-
-            density[label] = values.split(",")
-
-            # TODO: check if they are in the atlas
-
-        config["density"] = density
+        config["output_density"] = output_density

--- a/hippunfold/plugins/atlas.py
+++ b/hippunfold/plugins/atlas.py
@@ -174,8 +174,8 @@ class AtlasConfig(PluginBase):
             type=str,
             dest="density",
             default=[
-                "hipp=272,1k,2k,4k,7k,10k,14k,18k,22k,27k,62k",
-                "dentate=34,129,301,536,842,1k,2k,3k,8k,13k",
+                "hipp=21k",
+                "dentate=3k",
             ],
             nargs="+",
             help=(

--- a/hippunfold/workflow/rules/atlas_gen.smk
+++ b/hippunfold/workflow/rules/atlas_gen.smk
@@ -288,7 +288,7 @@ rule make_metric_ref:
             template=config["new_atlas_name"],
             label="{label}",
             hemi="{hemi}",
-            suffix="gyrification.nii.gz",
+            suffix="{metric}.nii.gz".format(metric=config["atlas_metrics"][0]),
         ),
     output:
         metric_ref=temp(
@@ -306,7 +306,7 @@ rule make_metric_ref:
     conda:
         conda_env("c3d")
     shell:
-        "c2d {input} -resample {wildcards.resample}% -threshold 0.1 inf 1 0 -o {output}"
+        "c2d {input} -resample {wildcards.resample}% -scale 0 -shift 1 -binarize -o {output}"
 
 
 rule gen_unfold_atlas_mesh:

--- a/hippunfold/workflow/rules/common.smk
+++ b/hippunfold/workflow/rules/common.smk
@@ -103,23 +103,23 @@ def get_modality_suffix(modality):
 def get_final_spec():
     specs = []
 
-    for label in config["autotop_labels"]:
-        specs.extend(
-            inputs[config["modality"]].expand(
-                bids(
-                    root=root,
-                    datatype="surf",
-                    space="{space}",
-                    label=label,
-                    den="{density}",
-                    suffix="surfaces.spec",
-                    **inputs.subj_wildcards,
-                ),
-                space=ref_spaces,
-                density=config["density"][label],
-                allow_missing=True,
-            )
+    specs.extend(
+        inputs[config["modality"]].expand(
+            bids(
+                root=root,
+                datatype="surf",
+                space="{space}",
+                label="{label}",
+                den="{density}",
+                suffix="surfaces.spec",
+                **inputs.subj_wildcards,
+            ),
+            space=ref_spaces,
+            label=config["autotop_labels"],
+            density=config["output_density"],
+            allow_missing=True,
         )
+    )
     specs.extend(
         inputs[config["modality"]].expand(
             bids(
@@ -217,26 +217,26 @@ def get_final_qc():
             allow_missing=True,
         )
     )
-    for label in config["autotop_labels"]:
-        qc.extend(
-            inputs[config["modality"]].expand(
-                bids(
-                    root=root,
-                    datatype="qc",
-                    suffix="midthickness.surf.png",
-                    den="{density}",
-                    desc="subfields",
-                    space="{space}",
-                    hemi="{hemi}",
-                    label=label,
-                    **inputs.subj_wildcards,
-                ),
-                hemi=config["hemi"],
-                density=config["density"][label],
-                space=ref_spaces,
-                allow_missing=True,
-            )
+    qc.extend(
+        inputs[config["modality"]].expand(
+            bids(
+                root=root,
+                datatype="qc",
+                suffix="midthickness.surf.png",
+                den="{density}",
+                desc="subfields",
+                space="{space}",
+                hemi="{hemi}",
+                label="{label}",
+                **inputs.subj_wildcards,
+            ),
+            hemi=config["hemi"],
+            density=config["output_density"],
+            label=config["autotop_labels"],
+            space=ref_spaces,
+            allow_missing=True,
         )
+    )
     if len(config["hemi"]) == 2:
         qc.extend(
             inputs[config["modality"]].expand(

--- a/hippunfold/workflow/rules/native_surf.smk
+++ b/hippunfold/workflow/rules/native_surf.smk
@@ -474,7 +474,7 @@ rule warp_native_mesh_to_unfold:
                 datatype="surf",
                 suffix="{surfname,midthickness}.surf.gii",
                 desc="nostruct",
-                space="unfolduneven",
+                space="unfold",
                 hemi="{hemi}",
                 label="{label}",
                 **inputs.subj_wildcards,
@@ -490,102 +490,102 @@ rule warp_native_mesh_to_unfold:
         "../scripts/rewrite_vertices_to_flat.py"
 
 
-rule space_unfold_vertices:
-    """ this irons out the surface to result in more even
-        vertex spacing. the resulting shape will be more 
-        individual (e.g. the surface area in unfolded space 
-        would be similar to native) """
-    input:
-        surf_gii=bids(
-            root=root,
-            datatype="surf",
-            suffix="midthickness.surf.gii",
-            desc="nostruct",
-            space="unfolduneven",
-            hemi="{hemi}",
-            label="{label}",
-            **inputs.subj_wildcards,
-        ),
-        native_gii=bids(
-            root=root,
-            datatype="surf",
-            suffix="midthickness.surf.gii",
-            space="corobl",
-            hemi="{hemi}",
-            label="{label}",
-            **inputs.subj_wildcards,
-        ),
-    params:
-        step_size=0.1,
-        max_iterations=10000,
-    output:
-        surf_gii=temp(
-            bids(
-                root=root,
-                datatype="surf",
-                suffix="midthickness.surf.gii",
-                desc="nostruct",
-                space="unfoldspringmodel",
-                hemi="{hemi}",
-                label="{label}",
-                **inputs.subj_wildcards,
-            )
-        ),
-    container:
-        config["singularity"]["autotop"]
-    conda:
-        conda_env("pyvista")
-    group:
-        "subj"
-    log:
-        bids(
-            root="logs",
-            suffix="log.txt",
-            datatype="space_unfold_vertices",
-            hemi="{hemi}",
-            label="{label}",
-            **inputs.subj_wildcards,
-        ),
-    script:
-        "../scripts/space_unfold_vertices.py"
+# rule space_unfold_vertices:
+#     """ this irons out the surface to result in more even
+#         vertex spacing. the resulting shape will be more 
+#         individual (e.g. the surface area in unfolded space 
+#         would be similar to native) """
+#     input:
+#         surf_gii=bids(
+#             root=root,
+#             datatype="surf",
+#             suffix="midthickness.surf.gii",
+#             desc="nostruct",
+#             space="unfolduneven",
+#             hemi="{hemi}",
+#             label="{label}",
+#             **inputs.subj_wildcards,
+#         ),
+#         native_gii=bids(
+#             root=root,
+#             datatype="surf",
+#             suffix="midthickness.surf.gii",
+#             space="corobl",
+#             hemi="{hemi}",
+#             label="{label}",
+#             **inputs.subj_wildcards,
+#         ),
+#     params:
+#         step_size=0.1,
+#         max_iterations=10000,
+#     output:
+#         surf_gii=temp(
+#             bids(
+#                 root=root,
+#                 datatype="surf",
+#                 suffix="midthickness.surf.gii",
+#                 desc="nostruct",
+#                 space="unfoldspringmodel",
+#                 hemi="{hemi}",
+#                 label="{label}",
+#                 **inputs.subj_wildcards,
+#             )
+#         ),
+#     container:
+#         config["singularity"]["autotop"]
+#     conda:
+#         conda_env("pyvista")
+#     group:
+#         "subj"
+#     log:
+#         bids(
+#             root="logs",
+#             suffix="log.txt",
+#             datatype="space_unfold_vertices",
+#             hemi="{hemi}",
+#             label="{label}",
+#             **inputs.subj_wildcards,
+#         ),
+#     script:
+#         "../scripts/space_unfold_vertices.py"
 
 
-rule unfold_surface_smoothing:
-    input:
-        surf_gii=bids(
-            root=root,
-            datatype="surf",
-            suffix="midthickness.surf.gii",
-            desc="nostruct",
-            space="unfoldspringmodel",
-            hemi="{hemi}",
-            label="{label}",
-            **inputs.subj_wildcards,
-        ),
-    params:
-        strength=1,
-        iterations=5,
-    output:
-        surf_gii=temp(
-            bids(
-                root=root,
-                datatype="surf",
-                suffix="midthickness.surf.gii",
-                desc="nostruct",
-                space="unfold",
-                hemi="{hemi}",
-                label="{label}",
-                **inputs.subj_wildcards,
-            )
-        ),
-    container:
-        config["singularity"]["autotop"]
-    conda:
-        conda_env("workbench")
-    group:
-        "subj"
-    shell:
-        "wb_command -surface-smoothing {input} {params} {output}"
+# rule unfold_surface_smoothing:
+#     input:
+#         surf_gii=bids(
+#             root=root,
+#             datatype="surf",
+#             suffix="midthickness.surf.gii",
+#             desc="nostruct",
+#             space="unfoldspringmodel",
+#             hemi="{hemi}",
+#             label="{label}",
+#             **inputs.subj_wildcards,
+#         ),
+#     params:
+#         strength=1,
+#         iterations=5,
+#     output:
+#         surf_gii=temp(
+#             bids(
+#                 root=root,
+#                 datatype="surf",
+#                 suffix="midthickness.surf.gii",
+#                 desc="nostruct",
+#                 space="unfold",
+#                 hemi="{hemi}",
+#                 label="{label}",
+#                 **inputs.subj_wildcards,
+#             )
+#         ),
+#     container:
+#         config["singularity"]["autotop"]
+#     conda:
+#         conda_env("workbench")
+#     group:
+#         "subj"
+#     shell:
+#         "wb_command -surface-smoothing {input} {params} {output}"
 
 
 rule set_surface_z_level:
@@ -1142,8 +1142,7 @@ rule resample_native_surf_to_atlas_density:
         ),
         native_unfold=get_unfold_ref,
     output:
-        native_resampled=temp(
-            bids(
+        native_resampled=bids(
                 root=root,
                 datatype="surf",
                 suffix="{surf_name,midthickness|inner|outer}.surf.gii",
@@ -1152,7 +1151,6 @@ rule resample_native_surf_to_atlas_density:
                 hemi="{hemi}",
                 label="{label}",
                 **inputs.subj_wildcards,
-            )
         ),
     container:
         config["singularity"]["autotop"]

--- a/hippunfold/workflow/rules/native_surf.smk
+++ b/hippunfold/workflow/rules/native_surf.smk
@@ -1254,7 +1254,7 @@ rule resample_atlas_subfields_to_native_surf:
             root=get_atlas_dir(),
             template=config["atlas"],
             hemi="{hemi}",
-            den=config["density"]["hipp"][0],
+            den=config["output_density"][0],
             label="{label}",
             suffix="dseg.label.gii",
         ),
@@ -1264,7 +1264,7 @@ rule resample_atlas_subfields_to_native_surf:
             hemi="{hemi}",
             label="{label}",
             space="unfold",
-            den=config["density"]["hipp"][0],
+            den=config["output_density"][0],
             suffix="midthickness.surf.gii",
         ),
     output:

--- a/hippunfold/workflow/rules/native_surf.smk
+++ b/hippunfold/workflow/rules/native_surf.smk
@@ -490,102 +490,101 @@ rule warp_native_mesh_to_unfold:
         "../scripts/rewrite_vertices_to_flat.py"
 
 
-# rule space_unfold_vertices:
-#     """ this irons out the surface to result in more even
-#         vertex spacing. the resulting shape will be more
-#         individual (e.g. the surface area in unfolded space
-#         would be similar to native) """
-#     input:
-#         surf_gii=bids(
-#             root=root,
-#             datatype="surf",
-#             suffix="midthickness.surf.gii",
-#             desc="nostruct",
-#             space="unfolduneven",
-#             hemi="{hemi}",
-#             label="{label}",
-#             **inputs.subj_wildcards,
-#         ),
-#         native_gii=bids(
-#             root=root,
-#             datatype="surf",
-#             suffix="midthickness.surf.gii",
-#             space="corobl",
-#             hemi="{hemi}",
-#             label="{label}",
-#             **inputs.subj_wildcards,
-#         ),
-#     params:
-#         step_size=0.1,
-#         max_iterations=10000,
-#     output:
-#         surf_gii=temp(
-#             bids(
-#                 root=root,
-#                 datatype="surf",
-#                 suffix="midthickness.surf.gii",
-#                 desc="nostruct",
-#                 space="unfoldspringmodel",
-#                 hemi="{hemi}",
-#                 label="{label}",
-#                 **inputs.subj_wildcards,
-#             )
-#         ),
-#     container:
-#         config["singularity"]["autotop"]
-#     conda:
-#         conda_env("pyvista")
-#     group:
-#         "subj"
-#     log:
-#         bids(
-#             root="logs",
-#             suffix="log.txt",
-#             datatype="space_unfold_vertices",
-#             hemi="{hemi}",
-#             label="{label}",
-#             **inputs.subj_wildcards,
-#         ),
-#     script:
-#         "../scripts/space_unfold_vertices.py"
+rule space_unfold_vertices:
+    """ this irons out the surface to result in more even
+        vertex spacing. the resulting shape will be more
+        individual (e.g. the surface area in unfolded space
+        would be similar to native) """
+    input:
+        surf_gii=bids(
+            root=root,
+            datatype="surf",
+            suffix="midthickness.surf.gii",
+            desc="nostruct",
+            space="unfold",
+            hemi="{hemi}",
+            label="{label}",
+            **inputs.subj_wildcards,
+        ),
+        native_gii=bids(
+            root=root,
+            datatype="surf",
+            suffix="midthickness.surf.gii",
+            space="corobl",
+            hemi="{hemi}",
+            label="{label}",
+            **inputs.subj_wildcards,
+        ),
+    params:
+        step_size=0.1,
+        max_iterations=10000,
+    output:
+        surf_gii=temp(
+            bids(
+                root=root,
+                datatype="surf",
+                suffix="midthickness.surf.gii",
+                desc="nostruct",
+                space="unfoldspringmodel",
+                hemi="{hemi}",
+                label="{label}",
+                **inputs.subj_wildcards,
+            )
+        ),
+    container:
+        config["singularity"]["autotop"]
+    conda:
+        conda_env("pyvista")
+    group:
+        "subj"
+    log:
+        bids(
+            root="logs",
+            suffix="log.txt",
+            datatype="space_unfold_vertices",
+            hemi="{hemi}",
+            label="{label}",
+            **inputs.subj_wildcards,
+        ),
+    script:
+        "../scripts/space_unfold_vertices.py"
 
 
-# rule unfold_surface_smoothing:
-#     input:
-#         surf_gii=bids(
-#             root=root,
-#             datatype="surf",
-#             suffix="midthickness.surf.gii",
-#             desc="nostruct",
-#             space="unfoldspringmodel",
-#             hemi="{hemi}",
-#             label="{label}",
-#             **inputs.subj_wildcards,
-#         ),
-#     params:
-#         strength=1,
-#         iterations=5,
-#     output:
-#         surf_gii=temp(
-#             bids(
-#                 root=root,
-#                 datatype="surf",
-#                 suffix="midthickness.surf.gii",
-#                 desc="nostruct",
-#                 space="unfold",
-#                 hemi="{hemi}",
-#                 label="{label}",
-#                 **inputs.subj_wildcards,
-#             )
-#         ),
-#     container:
-#         config["singularity"]["autotop"]
-#     conda:
-#         conda_env("workbench")
-#     group:
-#         "subj"
-#     shell:
-#         "wb_command -surface-smoothing {input} {params} {output}"
+rule unfold_surface_smoothing:
+    input:
+        surf_gii=bids(
+            root=root,
+            datatype="surf",
+            suffix="midthickness.surf.gii",
+            desc="nostruct",
+            space="unfoldspringmodel",
+            hemi="{hemi}",
+            label="{label}",
+            **inputs.subj_wildcards,
+        ),
+    params:
+        strength=1,
+        iterations=5,
+    output:
+        surf_gii=temp(
+            bids(
+                root=root,
+                datatype="surf",
+                suffix="midthickness.surf.gii",
+                space="unfoldspringmodelsmooth",
+                hemi="{hemi}",
+                label="{label}",
+                **inputs.subj_wildcards,
+            )
+        ),
+    container:
+        config["singularity"]["autotop"]
+    conda:
+        conda_env("workbench")
+    group:
+        "subj"
+    shell:
+        "wb_command -surface-smoothing {input} {params} {output}"
 
 
 rule set_surface_z_level:
@@ -991,7 +990,7 @@ rule calculate_legacy_gyrification:
             root=root,
             datatype="surf",
             suffix="surfarea.shape.gii",
-            space="unfold",
+            space="unfoldspringmodelsmooth",
             hemi="{hemi}",
             label="{label}",
             **inputs.subj_wildcards,

--- a/hippunfold/workflow/rules/native_surf.smk
+++ b/hippunfold/workflow/rules/native_surf.smk
@@ -492,8 +492,8 @@ rule warp_native_mesh_to_unfold:
 
 # rule space_unfold_vertices:
 #     """ this irons out the surface to result in more even
-#         vertex spacing. the resulting shape will be more 
-#         individual (e.g. the surface area in unfolded space 
+#         vertex spacing. the resulting shape will be more
+#         individual (e.g. the surface area in unfolded space
 #         would be similar to native) """
 #     input:
 #         surf_gii=bids(
@@ -1143,14 +1143,14 @@ rule resample_native_surf_to_atlas_density:
         native_unfold=get_unfold_ref,
     output:
         native_resampled=bids(
-                root=root,
-                datatype="surf",
-                suffix="{surf_name,midthickness|inner|outer}.surf.gii",
-                space="{space,unfoldreg|corobl}",
-                den="{density}",
-                hemi="{hemi}",
-                label="{label}",
-                **inputs.subj_wildcards,
+            root=root,
+            datatype="surf",
+            suffix="{surf_name,midthickness|inner|outer}.surf.gii",
+            space="{space,unfoldreg|corobl}",
+            den="{density}",
+            hemi="{hemi}",
+            label="{label}",
+            **inputs.subj_wildcards,
         ),
     container:
         config["singularity"]["autotop"]

--- a/hippunfold/workflow/rules/subfields.smk
+++ b/hippunfold/workflow/rules/subfields.smk
@@ -113,7 +113,7 @@ rule native_label_gii_to_unfold_nii:
             **inputs.subj_wildcards,
         ),
     params:
-        interp="-nearest-vertex 0.3",
+        interp="-nearest-vertex 10",
     output:
         label_nii=temp(
             bids(
@@ -134,7 +134,7 @@ rule native_label_gii_to_unfold_nii:
         "subj"
     shell:
         "wb_command -label-to-volume-mapping {input.label_gii} {input.midthickness_surf} {input.ref_nii} {output.label_nii} "
-        " -ribbon-constrained {input.inner_surf} {input.outer_surf}"
+        " {params.interp}"
 
 
 rule label_subfields_from_vol_coords_corobl:

--- a/hippunfold/workflow/rules/unfold_reg.smk
+++ b/hippunfold/workflow/rules/unfold_reg.smk
@@ -277,7 +277,7 @@ def get_moving_images_unfoldreg(wildcards):
             space="unfold2d",
             hemi="{hemi}",
             label="{label}",
-            den=config["density"][wildcards.label][0],
+            den=config["output_density"][0],
             atlas="{atlas}",
             **inputs.subj_wildcards,
         ),

--- a/hippunfold/workflow/rules/unfold_reg.smk
+++ b/hippunfold/workflow/rules/unfold_reg.smk
@@ -1,55 +1,11 @@
-rule pad_unfold_ref:
-    """pads the unfolded ref in XY (to improve registration by ensuring zero-displacement at boundaries)
-        and to deal with input vertices that are just slightly outside the original bounding box. 
-       The ribbon-constrained method will be used to resample surface metrics into this reference, then
-        to get a 2D slice we will take the central slice (the next rule creates the single-slice reference
-        for this)."""
-    input:
-        ref_nii=bids(
-            root=root,
-            space="unfold",
-            label="{label}",
-            datatype="warps",
-            suffix="refvol.nii.gz",
-            **inputs.subj_wildcards,
-        ),
-    params:
-        padding="-pad {unfoldreg_padding} {unfoldreg_padding}".format(
-            unfoldreg_padding=config["unfoldreg_padding"]
-        ),
-    output:
-        ref_nii=temp(
-            bids(
-                root=root,
-                datatype="anat",
-                suffix="refvol.nii.gz",
-                space="unfold",
-                desc="padded",
-                hemi="{hemi}",
-                label="{label}",
-                **inputs.subj_wildcards,
-            )
-        ),
-    container:
-        config["singularity"]["autotop"]
-    conda:
-        "../envs/c3d.yaml"
-    group:
-        "subj"
-    shell:
-        "c3d {input.ref_nii} -scale 0 -shift 1 {params.padding} 0 -o {output.ref_nii}"
-
-
 rule extract_unfold_ref_slice:
     """This gets the central-most slice of the unfold volume, for obtaining a 2D slice"""
     input:
         ref_3d_nii=bids(
             root=root,
-            datatype="anat",
+            datatype="warps",
             suffix="refvol.nii.gz",
             space="unfold",
-            desc="padded",
-            hemi="{hemi}",
             label="{label}",
             **inputs.subj_wildcards,
         ),
@@ -61,7 +17,6 @@ rule extract_unfold_ref_slice:
                 suffix="refvol.nii.gz",
                 space="unfold",
                 desc="slice",
-                hemi="{hemi}",
                 label="{label}",
                 **inputs.subj_wildcards,
             )
@@ -121,7 +76,6 @@ rule native_metric_to_unfold_nii:
             suffix="refvol.nii.gz",
             space="unfold",
             desc="slice",
-            hemi="{hemi}",
             label="{label}",
             **inputs.subj_wildcards,
         ),
@@ -132,7 +86,7 @@ rule native_metric_to_unfold_nii:
             bids(
                 root=root,
                 datatype="anat",
-                suffix="{metric}.nii.gz",
+                suffix="{metric,[0-9a-zA-Z]+}.nii.gz",
                 space="unfold",
                 hemi="{hemi}",
                 label="{label}",
@@ -160,7 +114,6 @@ rule atlas_metric_to_unfold_nii:
             suffix="refvol.nii.gz",
             space="unfold",
             desc="slice",
-            hemi="{hemi}",
             label="{label}",
             **inputs.subj_wildcards,
         ),
@@ -434,11 +387,9 @@ rule reset_header_2d_warp_unfoldreg:
         ),
         ref_nii=bids(
             root=root,
-            datatype="anat",
+            datatype="warps",
             suffix="refvol.nii.gz",
             space="unfold",
-            desc="padded",
-            hemi="{hemi}",
             label="{label}",
             **inputs.subj_wildcards,
         ),

--- a/hippunfold/workflow/rules/unfold_reg.smk
+++ b/hippunfold/workflow/rules/unfold_reg.smk
@@ -126,7 +126,7 @@ rule native_metric_to_unfold_nii:
             **inputs.subj_wildcards,
         ),
     params:
-        interp="-nearest-vertex 0.3",
+        interp="-nearest-vertex 10",
     output:
         metric_nii=temp(
             bids(
@@ -147,7 +147,7 @@ rule native_metric_to_unfold_nii:
         "subj"
     shell:
         "wb_command -metric-to-volume-mapping {input.metric_gii} {input.midthickness_surf} {input.ref_nii} {output.metric_nii} "
-        " -ribbon-constrained {input.inner_surf} {input.outer_surf}"
+        " {params.interp}"
 
 
 rule atlas_metric_to_unfold_nii:

--- a/hippunfold/workflow/scripts/resample_to_density_mapping.py
+++ b/hippunfold/workflow/scripts/resample_to_density_mapping.py
@@ -54,7 +54,7 @@ density_list = []
 
 rows = []
 
-for surf_gii in snakemake.input.surf_giis:
+for surf_gii in snakemake.input.hipp_surf_giis + snakemake.input.dentate_surf_giis:
     # get the resample value from the filename
     resample = re.search(r"_resample-(\d+)_", surf_gii).group(1)
     hemi = re.search(r"_hemi-([LR])_", surf_gii).group(1)


### PR DESCRIPTION
This is just an experiment to see what will happen, and discuss. This effectively throws away the "stingray" unfolded registration and sticks to the original 2:1 aspect ratio rectangle. It still uses the workflow to generate new atlases though, in this case still using the multihist7

![image](https://github.com/user-attachments/assets/79f40b54-aabc-4b05-a7a2-66e46b58c78c)

The original goal of the "stringray" space was to have more even vertex sampling, minimizing distortion between folded and unfolded space. We also generally wanted better quality reference surfaces, which we have achieved whether we include stingrays or not. However, there are also some pros to skipping this:

Pros:
- faster and (slightly) simpler workflow
- could drop the padding from unfolded space registration
- can avoid errors arising from springs + smoothing (e.g. edge vertices being crammed together)
- easier mapping back to old surface densities (i.e. by interpolation in unfolded space) (provided we use the same laplace coords and not geodesic distances)

To be honest, i think that we could drop the springs+smoothing, since the vertex spacing is not terribly different here (comparable to stingrays and maybe better for the edges). Plus this makes things easier to map onto HippoMaps and visualize with the folded+unfolded space.

One final thing to consider is that in unfolded template generation, we could drop affine and keep only syn registration (since all boundary conditions are initialized in the same place. I will try this out now, but i don't expect it to make a difference. 