### PR TITLE
finish write_template_json rule, pin atlases

### DIFF
--- a/hippunfold/plugins/atlas.py
+++ b/hippunfold/plugins/atlas.py
@@ -46,7 +46,7 @@ def sync_atlas_repo():
             repo.git.checkout(ATLAS_REPO_COMMIT)
         else:
             # If the directory does not exist, clone the repo
-            Repo.clone_from(repo_url, atlas_dir)
+            repo = Repo.clone_from(repo_url, atlas_dir)
             repo.git.checkout(ATLAS_REPO_COMMIT)
     except GitCommandError as e:
         logger.info(f"Error syncing atlas repository: {e}")

--- a/hippunfold/plugins/atlas.py
+++ b/hippunfold/plugins/atlas.py
@@ -17,6 +17,9 @@ logger = logging.getLogger(__name__)
 import json
 import os
 
+# Global variable to store the commit hash
+ATLAS_REPO_COMMIT = "7c292113c669a629773a644f82485ffde1842f52"
+
 
 def get_download_dir():
     if "HIPPUNFOLD_CACHE_DIR" in os.environ.keys():
@@ -40,9 +43,11 @@ def sync_atlas_repo():
             # If the directory exists and is a git repo, update it
             repo = Repo(atlas_dir)
             repo.remotes.origin.pull()
+            repo.git.checkout(ATLAS_REPO_COMMIT)
         else:
             # If the directory does not exist, clone the repo
             Repo.clone_from(repo_url, atlas_dir)
+            repo.git.checkout(ATLAS_REPO_COMMIT)
     except GitCommandError as e:
         logger.info(f"Error syncing atlas repository: {e}")
 

--- a/hippunfold/workflow/rules/atlas_gen.smk
+++ b/hippunfold/workflow/rules/atlas_gen.smk
@@ -808,3 +808,5 @@ rule write_template_json:
             )
             / "template_description.json"
         ),
+    script:
+        "../scripts/write_template_json.py"

--- a/hippunfold/workflow/scripts/write_template_json.py
+++ b/hippunfold/workflow/scripts/write_template_json.py
@@ -1,0 +1,4 @@
+import json
+
+with open(snakemake.output.json, "w") as f:
+    json.dump(snakemake.params.template_description, f, indent=4)


### PR DESCRIPTION
- finish up the write_template_json rule
- pin hippunfold-atlases to specific commit, uses global var in atlas plugin that needs to be changed to set the atlas commit, tag or branch..