### PR TITLE
Decimate unpro

### DIFF
--- a/hippunfold/workflow/rules/native_surf.smk
+++ b/hippunfold/workflow/rules/native_surf.smk
@@ -61,9 +61,7 @@ rule gen_native_mesh:
     params:
         threshold=lambda wildcards: surf_thresholds[wildcards.surfname],
         decimate_opts={
-            "reduction": 0.5,
-            "feature_angle": 25,
-            "preserve_topology": True,
+            "target_reduction": 0.5,
         },
         hole_fill_radius=1.0,
         morph_openclose_dist=2,  # mm

--- a/hippunfold/workflow/scripts/gen_isosurface.py
+++ b/hippunfold/workflow/scripts/gen_isosurface.py
@@ -148,7 +148,7 @@ logger.info(surface)
 
 # reduce # of vertices with decimation
 logger.info(f"Decimating surface with {snakemake.params.decimate_opts}")
-surface = surface.decimate_pro(**snakemake.params.decimate_opts)
+surface = surface.decimate(**snakemake.params.decimate_opts)
 logger.info(surface)
 
 


### PR DESCRIPTION
I'm not sure, but i think that decimate_pro may have been leaving in some perfectly overlapping vertices, possibly due to preserve_topology=True. Also _pro decimates flatter areas more, so this should be more appropriate anyway, affecting the unfolded spring model and then gyrification measure