### PR TITLE
LP uniform

### DIFF
--- a/hippunfold/workflow/scripts/laplace_beltrami.py
+++ b/hippunfold/workflow/scripts/laplace_beltrami.py
@@ -140,9 +140,13 @@ boundary_conditions = dict(
 coords = solve_laplace_beltrami_open_mesh(vertices, faces, boundary_conditions)
 
 # make fully uniform distribution
-domain = np.setdiff1d(np.arange(len(coords)), np.concatenate([src_indices, sink_indices])) # ignore src/sink indices
+domain = np.setdiff1d(
+    np.arange(len(coords)), np.concatenate([src_indices, sink_indices])
+)  # ignore src/sink indices
 sorted_indices = np.argsort(coords[domain])
-uniform_values = np.linspace(0, 1, len(domain)+2)[1:-1] # ignore first and last values
+uniform_values = np.linspace(0, 1, len(domain) + 2)[
+    1:-1
+]  # ignore first and last values
 coords[domain[sorted_indices]] = uniform_values
 
 # save the coordinates to a gifti file

--- a/hippunfold/workflow/scripts/laplace_beltrami.py
+++ b/hippunfold/workflow/scripts/laplace_beltrami.py
@@ -139,6 +139,13 @@ boundary_conditions = dict(
 
 coords = solve_laplace_beltrami_open_mesh(vertices, faces, boundary_conditions)
 
+# make fully uniform distribution
+domain = np.setdiff1d(np.arange(len(coords)), np.concatenate([src_indices, sink_indices])) # ignore src/sink indices
+sorted_indices = np.argsort(coords[domain])
+uniform_values = np.linspace(0, 1, len(domain)+2)[1:-1] # ignore first and last values
+coords[domain[sorted_indices]] = uniform_values
+
+# save the coordinates to a gifti file
 data_array = nib.gifti.GiftiDataArray(data=coords.astype(np.float32))
 image = nib.gifti.GiftiImage()
 


### PR DESCRIPTION
This rescales the Laplace coords to have a uniform distribution (while leaving source/sink alone at 0 or 1). This also makes the gradient steeper in the middle, helping provide more aligned vertices in those areas which need it most. Unlike the fast marching method (https://github.com/khanlab/hippunfold/pull/406), this also ensures no "wrinkles" taken by geodesic shortcuts. It doesn't guarantee alignment between the nearest hipp and dentate vertices like (https://github.com/khanlab/hippunfold/pull/415)