### PR TITLE
Mackenzie/same output folder warning

### DIFF
--- a/hippunfold/run.py
+++ b/hippunfold/run.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 import os
 from pathlib import Path
+import sys
+import warnings 
 
 from snakebids import bidsapp, plugins
 
@@ -11,6 +13,16 @@ try:
 except ImportError:
     from plugins import atlas as atlas_plugin  # Works when run directly
 
+
+def check_for_existing_process(output_dir):
+    snakebids_path = output_dir/".snakebids"
+    if snakebids_path.exists():
+        warnings.warn(
+            "Another .snakebids file has been detected in your output directory.\n"
+            "Please make sure only one snakebids process is writing to this output folder at a time."
+        )
+output_dir = Path(sys.argv[2]).resolve()
+check_for_existing_process(output_dir)
 
 if "__file__" not in globals():
     __file__ = "../hippunfold/run.py"

--- a/hippunfold/run.py
+++ b/hippunfold/run.py
@@ -15,8 +15,8 @@ except ImportError:
 
 
 def check_for_existing_process(output_dir):
-    snakebids_path = output_dir / ".snakebids"
-    if snakebids_path.exists():
+    snakebids_path = os.path.join(output_dir, "config", "snakebids.yml")
+    if os.path.exists(snakebids_path):
         warnings.warn(
             "Another .snakebids file has been detected in your output directory.\n"
             "Please make sure only one snakebids process is writing to this output folder at a time."

--- a/hippunfold/run.py
+++ b/hippunfold/run.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 import os
-from pathlib import Path
 import sys
-import warnings 
+import warnings
+from pathlib import Path
 
 from snakebids import bidsapp, plugins
 
@@ -15,12 +15,14 @@ except ImportError:
 
 
 def check_for_existing_process(output_dir):
-    snakebids_path = output_dir/".snakebids"
+    snakebids_path = output_dir / ".snakebids"
     if snakebids_path.exists():
         warnings.warn(
             "Another .snakebids file has been detected in your output directory.\n"
             "Please make sure only one snakebids process is writing to this output folder at a time."
         )
+
+
 output_dir = Path(sys.argv[2]).resolve()
 check_for_existing_process(output_dir)
 

--- a/hippunfold/run_quick.py
+++ b/hippunfold/run_quick.py
@@ -55,7 +55,6 @@ def gen_parser():
 def main():
     if check_conda_installation():
         print("Conda is ready to use.")
-        print("running......")
     else:
         print("Please install Conda to continue using hippunfold-quick.")
         sys.exit(1)
@@ -104,8 +103,10 @@ def main():
 
     # run the command
     try:
+        print("running......")
         subprocess.run(command, check=True)
-        print("hippunfold completed successfully.")
+        if not args.dry_run:
+            print("hippunfold completed successfully.")
     except subprocess.CalledProcessError as e:
         print(f"Error: {e}")
     finally:


### PR DESCRIPTION
- checks if a config/snakebids.yml file already exists in the output directory specified by the user
- if it does, a warning is sent to the terminal about two possible snakebids processes writing to the same output folder at the same time. Only a warning as if a previous process has already been completed, it should be ok if the config file is overwritten by the second process.
- for issue: #434 
- please let me know if this fully covers the problem discussed during the meeting on April 16th - I created the pr based off what I had noted down in the attached issue
