### PR TITLE
higher decimation; cleanup unused params

### DIFF
--- a/hippunfold/workflow/rules/native_isosurf.smk
+++ b/hippunfold/workflow/rules/native_isosurf.smk
@@ -47,12 +47,8 @@ rule gen_native_mesh:
         ),
     params:
         threshold=lambda wildcards: config["surf_thresholds"][wildcards.surfname],
-        decimate_opts={
-            "target_reduction": 0.5,
-        },
+        decimate_opts=0.75,
         hole_fill_radius=1.0,
-        morph_openclose_dist=2,  # mm
-        coords_epsilon=0.1,
     output:
         surf_gii=temp(
             temp(

--- a/hippunfold/workflow/scripts/gen_isosurface.py
+++ b/hippunfold/workflow/scripts/gen_isosurface.py
@@ -147,7 +147,7 @@ logger.info(surface)
 
 # reduce # of vertices with decimation
 logger.info(f"Decimating surface with {snakemake.params.decimate_opts}")
-surface = surface.decimate(**snakemake.params.decimate_opts)
+surface = surface.decimate(snakemake.params.decimate_opts)
 logger.info(surface)
 
 


### PR DESCRIPTION
removes some unused arguments, and sets decimation to 0.75, which yields around 50k vertices in the multihist7. This is still quite a bit, so we could be even more aggressive 