### PR TITLE
Dockerize conda

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,4 +4,4 @@
 DEFAULT_FLAGS="--use-conda --conda-prefix /src/conda-envs"
 
 # Run the command, passing the default flags and any additional arguments
-exec conda run --no-capture-output -n snakebids-env ./hippunfold/run.py "$DEFAULT_FLAGS" "$@"
+exec conda run --no-capture-output -n snakebids-env /src/hippunfold/run.py "$DEFAULT_FLAGS" "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,4 @@
 #!/bin/bash
 
-# Default flags to pass to run.py
-DEFAULT_FLAGS="--use-conda --conda-prefix /src/conda-envs"
-
 # Run the command, passing the default flags and any additional arguments
-exec conda run --no-capture-output -n snakebids-env /src/hippunfold/run.py "$DEFAULT_FLAGS" "$@"
+exec conda run --no-capture-output -n snakebids-env /src/hippunfold/run.py "$@"


### PR DESCRIPTION
Replace relative path to the run.py executable with its absolute path, and remove default flags, i.e., `--use-conda` and `--conda-prefix /src/conda-envs`. The latter is a quick hack and the user would have to pass those default flags from the command line but in future it would be more robust to integrate these flags in the pipeline from inside the docker image. 