### PR TITLE
Update docker CI

### DIFF
--- a/.github/workflows/push_container.yml
+++ b/.github/workflows/push_container.yml
@@ -6,6 +6,9 @@
 
 name: Publish Docker image
 on:
+  push:
+    branches:
+    - dev-v2.0.0
   workflow_dispatch:
   release:
     types: [published]


### PR DESCRIPTION
A new Docker image with the tag dev-v2.0.0 will be published every time there's a new commit to the `dev-v2.0.0` branch.