### PR TITLE
Refactor unzip command tool 

### DIFF
--- a/hippunfold/workflow/rules/download.smk
+++ b/hippunfold/workflow/rules/download.smk
@@ -25,7 +25,7 @@ rule download_extract_template:
 
         # 1) download the zip
         zip_path = os.path.join(outdir, "temp.zip")
-        urllib.request.urlretrieve(params.url, zip_path)
+        urllib.request.urlretrieve('https://' + params.url, zip_path)
 
         # 2) extract all files using Python's zipfile
         with zipfile.ZipFile(zip_path, 'r') as zf:

--- a/hippunfold/workflow/rules/download.smk
+++ b/hippunfold/workflow/rules/download.smk
@@ -15,9 +15,24 @@ rule download_extract_template:
         "minimal"
     conda:
         conda_env("curl")
-    shell:
-        "curl -L 'https://{params.url}' -o temp.zip && "
-        " unzip -d {output.unzip_dir} temp.zip"
+    run:
+        import os
+        import urllib.request
+        import zipfile
+
+        outdir = str(output.unzip_dir)
+        os.makedirs(outdir, exist_ok=True)
+
+        # 1) download the zip
+        zip_path = os.path.join(outdir, "temp.zip")
+        urllib.request.urlretrieve(params.url, zip_path)
+
+        # 2) extract all files using Python's zipfile
+        with zipfile.ZipFile(zip_path, 'r') as zf:
+            zf.extractall(outdir)
+
+        # 3) clean up
+        os.remove(zip_path)
 
 
 ## unpack template

--- a/hippunfold/workflow/rules/download.smk
+++ b/hippunfold/workflow/rules/download.smk
@@ -25,13 +25,13 @@ rule download_extract_template:
 
         # 1) download the zip
         zip_path = os.path.join(outdir, "temp.zip")
-        urllib.request.urlretrieve('https://' + params.url, zip_path)
+        urllib.request.urlretrieve("https://" + params.url, zip_path)
 
         # 2) extract all files using Python's zipfile
-        with zipfile.ZipFile(zip_path, 'r') as zf:
+        with zipfile.ZipFile(zip_path, "r") as zf:
             zf.extractall(outdir)
 
-        # 3) clean up
+            # 3) clean up
         os.remove(zip_path)
 
 

--- a/hippunfold/workflow/rules/download.smk
+++ b/hippunfold/workflow/rules/download.smk
@@ -13,23 +13,8 @@ rule download_extract_template:
         config["singularity"]["autotop"]
     shadow:
         "minimal"
-    conda:
-        conda_env("curl")
-    run:
-        import os
-        import urllib.request
-        import zipfile
-
-        outdir = str(output.unzip_dir)
-        os.makedirs(outdir, exist_ok=True)
-
-        zip_path = os.path.join(outdir, "temp.zip")
-        urllib.request.urlretrieve("https://" + params.url, zip_path)
-
-        with zipfile.ZipFile(zip_path, "r") as zf:
-            zf.extractall(outdir)
-
-        os.remove(zip_path)
+    script:
+        "../scripts/download.py"
 
 
 ## unpack template

--- a/hippunfold/workflow/rules/download.smk
+++ b/hippunfold/workflow/rules/download.smk
@@ -23,15 +23,12 @@ rule download_extract_template:
         outdir = str(output.unzip_dir)
         os.makedirs(outdir, exist_ok=True)
 
-        # 1) download the zip
         zip_path = os.path.join(outdir, "temp.zip")
         urllib.request.urlretrieve("https://" + params.url, zip_path)
 
-        # 2) extract all files using Python's zipfile
         with zipfile.ZipFile(zip_path, "r") as zf:
             zf.extractall(outdir)
 
-            # 3) clean up
         os.remove(zip_path)
 
 

--- a/hippunfold/workflow/scripts/download.py
+++ b/hippunfold/workflow/scripts/download.py
@@ -2,6 +2,7 @@ import os
 import urllib.request
 import zipfile
 
+
 def download_extract(unzip_dir, url):
 
     outdir = str(unzip_dir)
@@ -15,7 +16,8 @@ def download_extract(unzip_dir, url):
 
     os.remove(zip_path)
 
+
 unzip_dir = snakemake.output.unzip_dir
 url = snakemake.params.url
 
-download_extract(unzip_dir,url)
+download_extract(unzip_dir, url)

--- a/hippunfold/workflow/scripts/download.py
+++ b/hippunfold/workflow/scripts/download.py
@@ -1,0 +1,21 @@
+import os
+import urllib.request
+import zipfile
+
+def download_extract(unzip_dir, url):
+
+    outdir = str(unzip_dir)
+    os.makedirs(outdir, exist_ok=True)
+
+    zip_path = os.path.join(outdir, "temp.zip")
+    urllib.request.urlretrieve("https://" + url, zip_path)
+
+    with zipfile.ZipFile(zip_path, "r") as zf:
+        zf.extractall(outdir)
+
+    os.remove(zip_path)
+
+unzip_dir = snakemake.output.unzip_dir
+url = snakemake.params.url
+
+download_extract(unzip_dir,url)


### PR DESCRIPTION
This PR fixes issue #469 by refactoring the `download_extract_template` rule to use Python’s standard `zipfile` library instead of the `unzip` command-line tool.