### PR TITLE
Fix dentate holes

### DIFF
--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -543,6 +543,8 @@ shape_inject:
     - 8
   labels_reinsert:
     - 7
+  labels_overwrite:
+    - 2  
   label_smoothing_stdev: '0.5x0.5x0.5mm'
 
 

--- a/hippunfold/workflow/rules/shape_inject.smk
+++ b/hippunfold/workflow/rules/shape_inject.smk
@@ -413,7 +413,6 @@ rule reinsert_subject_labels:
         labels_overwrite=" ".join(
             str(label) for label in config["shape_inject"]["labels_overwrite"]
         ),
-
     output:
         postproc_seg=temp(
             bids(


### PR DESCRIPTION
Deals with large dentate holes (#464 ) caused by nnunet Cyst label.

This fix ensures re-inserted cyst label only overwrites SRLM, which should ensure it doesn't alter the topology present in the injected segmentation.

Note: There still seem to be some tiny holes that are present (e.g. in hcp subject 100307), but these seem to be related to the quality of the dentate src/sink labels defined in the template.. 