### PR TITLE
add label 6 to dentate tight crop

### DIFF
--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -613,6 +613,7 @@ tight_crop_labels: #defines what labels to use for tight cropping (for upsampled
     - 1
   dentate:
     - 8
+    - 6
 
 laminar_coords_res:
   hipp: 0.3x0.3x0.3mm


### PR DESCRIPTION
fixes errors occuring when it is completely left out of the cropped fov. Closes #479 