### PR TITLE
fix atlas plugin to be semi-functional when there is no internet connectivity

### DIFF
--- a/hippunfold/plugins/atlas.py
+++ b/hippunfold/plugins/atlas.py
@@ -149,15 +149,15 @@ def sync_atlas_repo():
                 repo = Repo(atlas_dir)
                 origin = repo.remotes.origin
                 origin.fetch()
-                
+
                 # Make sure the branch exists locally and tracks remote
                 if branch not in repo.heads:
-                    repo.git.checkout('-b', branch, f'origin/{branch}')
+                    repo.git.checkout("-b", branch, f"origin/{branch}")
                 else:
                     repo.git.checkout(branch)
 
                 # Pull latest updates (fast-forward only)
-                repo.git.pull('--ff-only')                
+                repo.git.pull("--ff-only")
             else:
                 logger.warning(
                     "WARNING: No internet connectivity, not updating the existing atlas repository"


### PR DESCRIPTION
Currently hippunfold will fail if there is no internet connectivity, since the atlas plugin tries to git fetch/clone with every CLI invocation.. This is bad since HPC nodes often don't have access to internet.. 

We now give a warning or error depending on internet connectivity:
if atlas repo exists, will just warn that updating will be skipped. if
it doesn't exist, will error out..

This also includes a fix where the updates to the branch were not being pulled in properly.. 