### PR TITLE
fixes the subfield-tissue jitter in volumetric dseg

### DIFF
--- a/hippunfold/workflow/scripts/label_gm_with_nearest_subfields.py
+++ b/hippunfold/workflow/scripts/label_gm_with_nearest_subfields.py
@@ -1,0 +1,33 @@
+import nibabel as nib
+import numpy as np
+from scipy.spatial import cKDTree
+
+# --- Load NIfTI files ---
+binary_img = nib.load(snakemake.input.gm)
+label_img = nib.load(snakemake.input.subfields)
+
+binary_data = binary_img.get_fdata().astype(np.uint8)
+label_data = label_img.get_fdata().astype(np.uint8)
+
+# --- Get voxel coordinates ---
+foreground_coords = np.argwhere(binary_data == 1)
+label_coords = np.argwhere(label_data > 0)
+label_values = label_data[label_data > 0]
+
+# --- Build KD-Tree on label coords ---
+tree = cKDTree(label_coords)
+
+# --- Find nearest labels for each foreground voxel ---
+_, nearest_idx = tree.query(foreground_coords)
+nearest_labels = label_values[nearest_idx]
+
+# --- Create output image ---
+output_data = np.zeros_like(binary_data)
+for i, coord in enumerate(foreground_coords):
+    output_data[tuple(coord)] = nearest_labels[i]
+
+# --- Save result ---
+output_img = nib.Nifti1Image(
+    output_data, affine=binary_img.affine, header=binary_img.header
+)
+nib.save(output_img, snakemake.output.subfields)


### PR DESCRIPTION
## Problem (copied from #499):

For the volumetric subfields output, in v1 we obtained the subfields by using the volumetric AP/PD coords, essentially looking up which coordinates map to each subfield, and painting the voxels accordingly. Then the SRLM, cyst and DG labels are added back in. Since the volumetric coords and tissue labels are all from the same source (eg the shape-injected nnunet segmentation), everything lines up.

However, since v2, we no longer have volumetric coords (since AP/PD is now estimated on the surface), so we have instead been obtaining subfields by wb_command label-to-volume-mapping. But this leads to some jitter (going vol -> surf -> vol), so the subfield labels do not line up well with the other tissue labels (SRLM specifically).. The jitter is actually pretty significant, as you can see below, with pretty big gaps..
 
## Fix

This fix imposes the original gm mask, using the surf-vol labels + dentate with a nearest voxel approach to fill in the gaps

Before:
<img width="3322" height="1936" alt="image" src="https://github.com/user-attachments/assets/312a4640-7f4c-497c-8675-0806580c2107" />

After:
<img width="3322" height="1936" alt="image" src="https://github.com/user-attachments/assets/d654a3f0-d3ae-427a-a33a-cef78a23bf29" />

Closes #499. 

Thanks @RicardoRios46 for bringing this to my attention.