### PR TITLE
updated approach for open isosurface creation

### DIFF
--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -542,6 +542,7 @@ laplace_labels:
     IO:
       gm:
         - 1
+        - 8
       src:
         - 2
         - 4


### PR DESCRIPTION
In principle this is a pretty simple fix, we just take out the extra dilated nan mask and then find a way to remove the unwanted components of the surface. This would be better than postprocessing to patch holes since it allows for a smooth&curvy surface. 
<img width="577" height="220" alt="image" src="https://github.com/user-attachments/assets/48eceaf4-f4ec-4a1e-acf9-b68983a58ef9" />
Here i tried keeping the second largest connected component but it must be connected somewhere because that effectively removes the whole thing
Would also need to remove from dg:
<img width="548" height="283" alt="image" src="https://github.com/user-attachments/assets/1e8ae2ac-cf19-48b8-8e6b-1cc7e268280e" />
some other masking of the bg might work, will look into it later