### PR TITLE
fix CLI arg parsing for laminar_coords_res

### DIFF
--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -170,12 +170,10 @@ parse_args:
   --laminar_coords_res_hipp:
     help: 'Set the resolution that the laminar (IO) coords will be computed with for hippocampus. This is implemented by resampling the segmentation to this resolution prior to generating the coords. (default: %(default)s)'
     default: '0.3x0.3x0.3mm'
-    dest: "laminar_coords_res.hipp"
 
   --laminar_coords_res_dentate:
     help: 'Set the resolution that the laminar (IO) coords will be computed with for the dentate gyrus. This is implemented by resampling the segmentation to this resolution prior to generating the coords. (default: %(default)s)'
     default: '0.1x0.1x0.1mm'
-    dest: "laminar_coords_res.dentate"
 
   --no_unfolded_reg:
     help: "Do not perform unfolded space (2D) registration based on surface metrics (e.g. thickness, curvature, and gyrification) for closer alignment to the reference atlas. (default: %(default)s)"
@@ -586,10 +584,6 @@ tight_crop_labels: #defines what labels to use for tight cropping (for upsampled
   dentate:
     - 8
     - 6
-
-laminar_coords_res:
-  hipp: 0.3x0.3x0.3mm
-  dentate: 0.1x0.1x0.1mm
 
 resample_dseg_for_templatereg: 0.3x0.3x0.3mm
 unfoldreg_padding: 0x0x0vox

--- a/hippunfold/workflow/rules/coords.smk
+++ b/hippunfold/workflow/rules/coords.smk
@@ -191,7 +191,7 @@ rule create_upsampled_coords_ref:
         seg=get_input_for_shape_inject,
     params:
         tight_crop_labels=lambda wildcards: config["tight_crop_labels"][wildcards.label],
-        resample_res=lambda wildcards: config["laminar_coords_res"][wildcards.label],
+        resample_res=lambda wildcards: config[f"laminar_coords_res_{wildcards.label}"],
         trim_padding="5mm",
     output:
         upsampled_ref=temp(


### PR DESCRIPTION
the destination variable wasn't being populated so the argument had no effect