### PR TITLE
untar of model in separate rule; only done once

### DIFF
--- a/hippunfold/workflow/rules/nnunet.smk
+++ b/hippunfold/workflow/rules/nnunet.smk
@@ -106,12 +106,12 @@ def get_cmd_copy_inputs(wildcards, input):
     in_img = input.in_img
     if isinstance(in_img, str):
         # we have one input image
-        return f"ln -s {in_img} tempimg/temp_0000.nii.gz"
+        return f"cp {in_img} tempimg/temp_0000.nii.gz"
     else:
         cmd = []
         # we have multiple input images
         for i, img in enumerate(input.in_img):
-            cmd.append(f"ln -s {img} tempimg/temp_{i:04d}.nii.gz")
+            cmd.append(f"cp {img} tempimg/temp_{i:04d}.nii.gz")
         return " && ".join(cmd)
 
 

--- a/hippunfold/workflow/rules/nnunet.smk
+++ b/hippunfold/workflow/rules/nnunet.smk
@@ -111,16 +111,25 @@ def get_cmd_copy_inputs(wildcards, input):
         return " && ".join(cmd)
 
 
+rule unpack_nnunet_model:
+    """ Unpack nnunet model tar to temp folder to check contents"""
+    input:
+        get_model_tar(),
+    output:
+        get_model_tar() + "unpacked",
+    shell:
+        "mkdir -p {output} && tar -xf {input} -C {output}"
+
+
 rule run_inference:
     """ This rule uses either GPU or CPU .
     It also runs in an isolated folder (shadow), with symlinks to inputs in that folder, copying over outputs once complete, so temp files are not retained"""
     input:
         in_img=get_nnunet_input,
-        model_tar=get_model_tar(),
+        model_dir=get_model_tar() + "unpacked",
     params:
         cmd_copy_inputs=get_cmd_copy_inputs,
         temp_lbl="templbl/temp.nii.gz",
-        model_dir="tempmodel",
         in_folder="tempimg",
         out_folder="templbl",
         task=parse_task_from_tar,
@@ -159,15 +168,13 @@ rule run_inference:
     shell:
         #create temp folders
         #cp input image to temp folder
-        #extract model
         #set nnunet env var to point to model
         #set threads
         # run inference
         #copy from temp output folder to final output
-        "mkdir -p {params.model_dir} {params.in_folder} {params.out_folder} && "
+        "mkdir -p {params.in_folder} {params.out_folder} && "
         "{params.cmd_copy_inputs} && "
-        "tar -xf {input.model_tar} -C {params.model_dir} && "
-        "export RESULTS_FOLDER={params.model_dir} && "
+        "export RESULTS_FOLDER={input.model_dir} && "
         "export nnUNet_n_proc_DA={threads} && "
         "nnUNet_predict -i {params.in_folder} -o {params.out_folder} -t {params.task} -chk {params.chkpnt} -tr {params.trainer} {params.tta} &> {log} && "
         "cp {params.temp_lbl} {output.nnunet_seg}"

--- a/hippunfold/workflow/rules/nnunet.smk
+++ b/hippunfold/workflow/rules/nnunet.smk
@@ -116,7 +116,11 @@ rule unpack_nnunet_model:
     input:
         get_model_tar(),
     output:
-        get_model_tar() + "unpacked",
+        Path(download_dir)
+        / "model"
+        / config["resource_urls"]["nnunet_model"][config["force_nnunet_model"]]
+        if config["force_nnunet_model"]
+        else config["resource_urls"]["nnunet_model"][config["modality"]] + "unpacked",
     shell:
         "mkdir -p {output} && tar -xf {input} -C {output}"
 
@@ -126,7 +130,15 @@ rule run_inference:
     It also runs in an isolated folder (shadow), with symlinks to inputs in that folder, copying over outputs once complete, so temp files are not retained"""
     input:
         in_img=get_nnunet_input,
-        model_dir=get_model_tar() + "unpacked",
+        model_tar=get_model_tar(),
+        model_dir=(
+            Path(download_dir)
+            / "model"
+            / config["resource_urls"]["nnunet_model"][config["force_nnunet_model"]]
+            if config["force_nnunet_model"]
+            else config["resource_urls"]["nnunet_model"][config["modality"]]
+            + "unpacked"
+        ),
     params:
         cmd_copy_inputs=get_cmd_copy_inputs,
         temp_lbl="templbl/temp.nii.gz",

--- a/hippunfold/workflow/rules/nnunet.smk
+++ b/hippunfold/workflow/rules/nnunet.smk
@@ -52,7 +52,11 @@ def get_model_tar():
     if local_tar == None:
         print(f"ERROR: {model_name} does not exist in nnunet_model in the config file")
 
-    return (Path(download_dir) / "model" / Path(local_tar).name).absolute()
+    return str((Path(download_dir) / "model" / Path(local_tar).name).absolute())
+
+
+def get_model_dir():
+    return get_model_tar().removesuffix(".tar")
 
 
 rule download_nnunet_model:
@@ -64,37 +68,37 @@ rule download_nnunet_model:
         ),
         model_dir=Path(download_dir) / "model",
     output:
-        model_tar=get_model_tar(),
+        model_tar=temp(get_model_tar()),
     conda:
         "../envs/curl.yaml"
     shell:
         "mkdir -p {params.model_dir} && curl -L https://{params.url} -o {output}"
 
 
-def parse_task_from_tar(wildcards, input):
-    match = re.search(r"Task[0-9]{3}_[\w]+", input.model_tar)
+def parse_task_from_dir(wildcards, input):
+    match = re.search(r"Task[0-9]{3}_[\w]+", input.model_dir)
     if match:
         task = match.group(0)
     else:
-        raise ValueError("cannot parse Task from model tar")
+        raise ValueError("cannot parse Task from model dir")
     return task
 
 
-def parse_chkpnt_from_tar(wildcards, input):
-    match = re.search(r"^.*\.(\w+)\.tar", input.model_tar)
+def parse_chkpnt_from_dir(wildcards, input):
+    match = re.search(r"^.*\.(\w+)", input.model_dir)
     if match:
         chkpnt = match.group(1)
     else:
-        raise ValueError("cannot parse chkpnt from model tar")
+        raise ValueError("cannot parse chkpnt from model dir")
     return chkpnt
 
 
-def parse_trainer_from_tar(wildcards, input):
-    match = re.search(r"^.*\.(\w+)\..*.tar", input.model_tar)
+def parse_trainer_from_dir(wildcards, input):
+    match = re.search(r"^.*\.(\w+)\..*", input.model_dir)
     if match:
         trainer = match.group(1)
     else:
-        raise ValueError("cannot parse chkpnt from model tar")
+        raise ValueError("cannot parse chkpnt from model dir")
     return trainer
 
 
@@ -116,11 +120,7 @@ rule unpack_nnunet_model:
     input:
         get_model_tar(),
     output:
-        Path(download_dir)
-        / "model"
-        / config["resource_urls"]["nnunet_model"][config["force_nnunet_model"]]
-        if config["force_nnunet_model"]
-        else config["resource_urls"]["nnunet_model"][config["modality"]] + "unpacked",
+        directory(get_model_dir()),
     shell:
         "mkdir -p {output} && tar -xf {input} -C {output}"
 
@@ -131,22 +131,15 @@ rule run_inference:
     input:
         in_img=get_nnunet_input,
         model_tar=get_model_tar(),
-        model_dir=(
-            Path(download_dir)
-            / "model"
-            / config["resource_urls"]["nnunet_model"][config["force_nnunet_model"]]
-            if config["force_nnunet_model"]
-            else config["resource_urls"]["nnunet_model"][config["modality"]]
-            + "unpacked"
-        ),
+        model_dir=get_model_dir(),
     params:
         cmd_copy_inputs=get_cmd_copy_inputs,
         temp_lbl="templbl/temp.nii.gz",
         in_folder="tempimg",
         out_folder="templbl",
-        task=parse_task_from_tar,
-        chkpnt=parse_chkpnt_from_tar,
-        trainer=parse_trainer_from_tar,
+        task=parse_task_from_dir,
+        chkpnt=parse_chkpnt_from_dir,
+        trainer=parse_trainer_from_dir,
         tta="" if config["nnunet_enable_tta"] else "--disable_tta",
     output:
         nnunet_seg=temp(

--- a/hippunfold/workflow/rules/nnunet.smk
+++ b/hippunfold/workflow/rules/nnunet.smk
@@ -102,12 +102,12 @@ def get_cmd_copy_inputs(wildcards, input):
     in_img = input.in_img
     if isinstance(in_img, str):
         # we have one input image
-        return f"cp {in_img} tempimg/temp_0000.nii.gz"
+        return f"ln -s {in_img} tempimg/temp_0000.nii.gz"
     else:
         cmd = []
         # we have multiple input images
         for i, img in enumerate(input.in_img):
-            cmd.append(f"cp {img} tempimg/temp_{i:04d}.nii.gz")
+            cmd.append(f"ln -s {img} tempimg/temp_{i:04d}.nii.gz")
         return " && ".join(cmd)
 
 


### PR DESCRIPTION
I've been finding the run_inference step still pretty slow, especially on clusters where read/write is the major bottleneck. The previous behaviour of this step would untar the nnunet model into a local temporary directory, and then load it into memory. Here we will untar it in the cache directory. This will only need to be done once instead of on a per-subject basis. I hope that this will speed things up a bit. 

If the untar is interrupted, we should be able to --rerun-incomplete, but there could be some concern if it is interrupted so the model dir exists and is called by a different hippunfold run though.

I'm also replacing `cp` with `ln -s`. I think this should be fine since we're not supporting Windows outside of docker anyway