### PR TITLE
Simplify use of atlas in workflow

### DIFF
--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -436,7 +436,7 @@ resource_urls:
     synthseg_v0.2: 'zenodo.org/record/8184230/files/trained_model.3d_fullres.Task203_synthseg.nnUNetTrainerV2.model_best.tar'
     ADNI_T1w_v1: 'zenodo.org/record/15297857/files/trained_model.3d_fullres.Task301_ADNI_T1w_successful.nnUNetTrainer.tar'
   atlas: 
-    multihist7: 'zenodo.org/records/18446592/files/tpl-multihist7.zip'
+    multihist7: 'https://zenodo.org/records/18446592/files/tpl-multihist7.zip'
   template:
     CITI168: 'files.ca-1.osf.io/v1/resources/v8acf/providers/osfstorage/65395bf0282745121fb86a93/?zip='
     dHCP: 'files.ca-1.osf.io/v1/resources/v8acf/providers/osfstorage/65395bff13d27b123094c9b4/?zip='

--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -426,15 +426,15 @@ tissue_atlas_mapping:
 #these will be downloaded to ~/.cache/hippunfold
 resource_urls:
   nnunet_model:
-    T1w: 'zenodo.org/record/4508747/files/trained_model.3d_fullres.Task101_hcp1200_T1w.nnUNetTrainerV2.model_best.tar'
-    T2w: 'zenodo.org/record/4508747/files/trained_model.3d_fullres.Task102_hcp1200_T2w.nnUNetTrainerV2.model_best.tar'
-    hippb500: 'zenodo.org/record/5732291/files/trained_model.3d_fullres.Task110_hcp1200_b1000crop.nnUNetTrainerV2.model_best.tar'
-    neonateT1w: 'zenodo.org/record/5733556/files/trained_model.3d_fullres.Task205_hcp1200_b1000_finetuneround2_dhcp_T1w.nnUNetTrainerV2.model_best.tar'
-    neonateT1w_v2: 'zenodo.org/record/8209029/files/trained_model.3d_fullres.Task301_dhcp_T1w_synthseg_manuallycorrected.nnUNetTrainer.model_best.tar'
-    T1T2w: 'zenodo.org/record/4508747/files/trained_model.3d_fullres.Task103_hcp1200_T1T2w.nnUNetTrainerV2.model_best.tar'
-    synthseg_v0.1: 'zenodo.org/record/8184230/files/trained_model.3d_fullres.Task102_synsegGenDetailed.nnUNetTrainerV2.model_best.tar'
-    synthseg_v0.2: 'zenodo.org/record/8184230/files/trained_model.3d_fullres.Task203_synthseg.nnUNetTrainerV2.model_best.tar'
-    ADNI_T1w_v1: 'zenodo.org/record/15297857/files/trained_model.3d_fullres.Task301_ADNI_T1w_successful.nnUNetTrainer.tar'
+    T1w: 'https://zenodo.org/record/4508747/files/trained_model.3d_fullres.Task101_hcp1200_T1w.nnUNetTrainerV2.model_best.tar'
+    T2w: 'https://zenodo.org/record/4508747/files/trained_model.3d_fullres.Task102_hcp1200_T2w.nnUNetTrainerV2.model_best.tar'
+    hippb500: 'https://zenodo.org/record/5732291/files/trained_model.3d_fullres.Task110_hcp1200_b1000crop.nnUNetTrainerV2.model_best.tar'
+    neonateT1w: 'https://zenodo.org/record/5733556/files/trained_model.3d_fullres.Task205_hcp1200_b1000_finetuneround2_dhcp_T1w.nnUNetTrainerV2.model_best.tar'
+    neonateT1w_v2: 'https://zenodo.org/record/8209029/files/trained_model.3d_fullres.Task301_dhcp_T1w_synthseg_manuallycorrected.nnUNetTrainer.model_best.tar'
+    T1T2w: 'https://zenodo.org/record/4508747/files/trained_model.3d_fullres.Task103_hcp1200_T1T2w.nnUNetTrainerV2.model_best.tar'
+    synthseg_v0.1: 'https://zenodo.org/record/8184230/files/trained_model.3d_fullres.Task102_synsegGenDetailed.nnUNetTrainerV2.model_best.tar'
+    synthseg_v0.2: 'https://zenodo.org/record/8184230/files/trained_model.3d_fullres.Task203_synthseg.nnUNetTrainerV2.model_best.tar'
+    ADNI_T1w_v1: 'https://zenodo.org/record/15297857/files/trained_model.3d_fullres.Task301_ADNI_T1w_successful.nnUNetTrainer.tar'
   atlas: 
     multihist7: 'https://zenodo.org/records/18451323/files/tpl-multihist7_flatdir.zip'
   template:

--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -436,7 +436,7 @@ resource_urls:
     synthseg_v0.2: 'zenodo.org/record/8184230/files/trained_model.3d_fullres.Task203_synthseg.nnUNetTrainerV2.model_best.tar'
     ADNI_T1w_v1: 'zenodo.org/record/15297857/files/trained_model.3d_fullres.Task301_ADNI_T1w_successful.nnUNetTrainer.tar'
   atlas: 
-    multihist7: 'https://zenodo.org/records/18446592/files/tpl-multihist7.zip'
+    multihist7: 'https://zenodo.org/records/18451323/files/tpl-multihist7_flatdir.zip'
   template:
     CITI168: 'files.ca-1.osf.io/v1/resources/v8acf/providers/osfstorage/65395bf0282745121fb86a93/?zip='
     dHCP: 'files.ca-1.osf.io/v1/resources/v8acf/providers/osfstorage/65395bff13d27b123094c9b4/?zip='

--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -435,14 +435,8 @@ resource_urls:
     synthseg_v0.1: 'zenodo.org/record/8184230/files/trained_model.3d_fullres.Task102_synsegGenDetailed.nnUNetTrainerV2.model_best.tar'
     synthseg_v0.2: 'zenodo.org/record/8184230/files/trained_model.3d_fullres.Task203_synthseg.nnUNetTrainerV2.model_best.tar'
     ADNI_T1w_v1: 'zenodo.org/record/15297857/files/trained_model.3d_fullres.Task301_ADNI_T1w_successful.nnUNetTrainer.tar'
-  atlas:
-    bbhist: 'www.dropbox.com/scl/fi/fdqujkekhlzbnxsah5kqr/atlas-bbhist_20250108.zip?rlkey=dupo8jtwjynbdou6xmr736txt&st=aiaqzpri&dl=0'
-    multihist7: 'www.dropbox.com/scl/fi/g07u7la7v1kwfgsty6ujc/atlas-multihist7_20250108.zip?rlkey=bi7wbdsm93upgnn3bmlv4f1hx&st=5iv33isc&dl=0'
-    # bigbrain: 'files.ca-1.osf.io/v1/resources/v8acf/providers/osfstorage/65395b8b13d27b123094c96f/?zip='
-    # magdeburg: 'files.ca-1.osf.io/v1/resources/v8acf/providers/osfstorage/65395b8013d27b122f94c938/?zip='
-    # freesurfer: 'files.ca-1.osf.io/v1/resources/v8acf/providers/osfstorage/65395b8513d27b123094c96a/?zip='
-    # macaque: 'files.ca-1.osf.io/v1/resources/v8acf/providers/osfstorage/6661f504d835c42bcb4cddab/?zip='
-    # mouse: 'files.ca-1.osf.io/v1/resources/v8acf/providers/osfstorage/666884380f8c80103a3c9569/?zip='
+  atlas: 
+    multihist7: 'zenodo.org/records/18444562/files/tpl-multihist7.zip'
   template:
     CITI168: 'files.ca-1.osf.io/v1/resources/v8acf/providers/osfstorage/65395bf0282745121fb86a93/?zip='
     dHCP: 'files.ca-1.osf.io/v1/resources/v8acf/providers/osfstorage/65395bff13d27b123094c9b4/?zip='

--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -436,7 +436,7 @@ resource_urls:
     synthseg_v0.2: 'zenodo.org/record/8184230/files/trained_model.3d_fullres.Task203_synthseg.nnUNetTrainerV2.model_best.tar'
     ADNI_T1w_v1: 'zenodo.org/record/15297857/files/trained_model.3d_fullres.Task301_ADNI_T1w_successful.nnUNetTrainer.tar'
   atlas: 
-    multihist7: 'zenodo.org/records/18444562/files/tpl-multihist7.zip'
+    multihist7: 'zenodo.org/records/18446592/files/tpl-multihist7.zip'
   template:
     CITI168: 'files.ca-1.osf.io/v1/resources/v8acf/providers/osfstorage/65395bf0282745121fb86a93/?zip='
     dHCP: 'files.ca-1.osf.io/v1/resources/v8acf/providers/osfstorage/65395bff13d27b123094c9b4/?zip='

--- a/hippunfold/plugins/atlas.py
+++ b/hippunfold/plugins/atlas.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import argparse
 import logging
-import socket
-import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -78,6 +76,57 @@ def get_unused_densities(output_density):
 # snakebids plugin definition
 
 
+def load_atlas_configs(atlas_dirs):
+    """
+    Loads surface atlas configurations from multiple directories.
+
+    Args:
+        atlas_dirs (list of str or Path): List of directories to search for surface atlas.
+        The later directories in the list override the earlier ones.
+
+    Returns:
+        dict: A dictionary where keys are atlas names and values are their configurations.
+    """
+    atlas = {}
+
+    for atlas_dir in atlas_dirs:
+        atlas_path = Path(atlas_dir)
+        if not atlas_path.exists():
+            continue
+
+        for subdir in atlas_path.iterdir():
+            if subdir.is_dir():
+                template_json = subdir / "template_description.json"
+                if template_json.exists():
+                    try:
+                        with open(template_json, "r") as f:
+                            config_data = json.load(f)
+                        atlas[subdir.name.removeprefix("tpl-")] = (
+                            config_data  # Override existing atlas if needed
+                        )
+                    except (json.JSONDecodeError, IOError) as e:
+                        print(f"Warning: Failed to load {template_json}: {e}")
+
+    return atlas
+
+
+def get_atlas_configs():
+    """
+    Gets surface atlas configurations from the cache directory.
+
+    Returns:
+        dict: Merged atlas configurations, prioritizing user-defined ones.
+    """
+
+    # Define search locations
+    cache_dir = utils.get_download_dir()
+
+    atlas_dirs = []
+    atlas_dirs.append(Path(cache_dir) / "atlases")
+
+    return load_atlas_configs(atlas_dirs)
+
+
 @attrs.define
 class AtlasConfig(PluginBase):
     """Dynamically add CLI parameters for the atlas.
@@ -95,6 +144,7 @@ class AtlasConfig(PluginBase):
     """
 
     argument_group: str | None = None
+    atlas_config: dict = attrs.field(factory=get_atlas_configs)
 
     @bidsapp.hookimpl
     def add_cli_arguments(
@@ -109,7 +159,6 @@ class AtlasConfig(PluginBase):
         self.try_add_argument(
             group,
             "--atlas",
-            choices=ATLASES,
             action="store",
             type=str,
             dest="atlas",
@@ -196,4 +245,7 @@ class AtlasConfig(PluginBase):
             DEFAULT_RESAMPLE_FACTORS
         )
         config["unused_density"] = get_unused_densities(output_density)
+        config["builtin_atlases"] = ATLASES
+
         config["atlas_metadata"] = ATLAS_METADATA
+        config["atlas_metadata"].update(self.atlas_config)

--- a/hippunfold/plugins/atlas.py
+++ b/hippunfold/plugins/atlas.py
@@ -39,7 +39,7 @@ ATLAS_METADATA = {
 
 
 DEFAULT_OUTPUT_DENSITY = ["8k"]
-OUTPUT_DENSITIES = ["native","512", "2k", "8k", "18k"]
+OUTPUT_DENSITIES = ["native", "512", "2k", "8k", "18k"]
 
 # Default settings for atlas creation
 DEFAULT_RESAMPLE_FACTORS = [

--- a/hippunfold/plugins/atlas.py
+++ b/hippunfold/plugins/atlas.py
@@ -39,7 +39,7 @@ ATLAS_METADATA = {
 
 
 DEFAULT_OUTPUT_DENSITY = ["8k"]
-OUTPUT_DENSITIES = ["512", "2k", "8k", "18k"]
+OUTPUT_DENSITIES = ["native","512", "2k", "8k", "18k"]
 
 # Default settings for atlas creation
 DEFAULT_RESAMPLE_FACTORS = [

--- a/hippunfold/plugins/atlas.py
+++ b/hippunfold/plugins/atlas.py
@@ -9,7 +9,6 @@ from typing import Any
 
 import attrs
 from appdirs import AppDirs
-from git import GitCommandError, Repo, cmd
 from snakebids import bidsapp
 from snakebids.bidsapp.args import ArgumentGroups
 from snakebids.plugins.base import PluginBase
@@ -27,10 +26,20 @@ except ImportError:
 # ====================================================================================
 # This section is edited by hand:
 # ------------------------------------------------------------------------------------
-# Global variable to store the commit hash or branch name
-ATLAS_REPO_COMMIT = "atlas-cli"
+
+ATLASES = ["multihist7"]
+DEFAULT_ATLAS = "multihist7"
+
+ATLAS_METADATA = {
+    "multihist7": {
+        "metric_wildcards": ["curvature", "gyrification", "thickness"],
+        "label_wildcards": ["hipp", "dentate"],
+    }
+}
+
 
 DEFAULT_OUTPUT_DENSITY = ["8k"]
+OUTPUT_DENSITIES = ["512", "2k", "8k", "18k"]
 
 # Default settings for atlas creation
 DEFAULT_RESAMPLE_FACTORS = [
@@ -61,190 +70,9 @@ def resample_factors_to_densities(resample_factors):
     return [resample_to_density(r) for r in resample_factors]
 
 
-def sort_densities(densities):
-    def parse_density(d):
-        if isinstance(d, str) and d.endswith("k"):
-            return int(float(d[:-1]) * 1000)
-        return int(d)
-
-    return sorted(densities, key=parse_density)
-
-
-def get_all_densities(atlas_config):
-    """Return a sorted list of all unique output densities across all atlases."""
-    densities = set()
-    for config in atlas_config.values():
-        densities.update(config.get("density_wildcards", []))
-    return ["native"] + sort_densities(densities)
-
-
-def get_unfoldreg_density(atlas_config, atlas):
-    """Get the density to use for unfoldreg, which is the highest density available for the chosen atlas."""
-    return sort_densities(atlas_config[atlas]["density_wildcards"])[-1]
-
-
-def get_unused_densities(atlas_config, atlas, output_density):
+def get_unused_densities(output_density):
     """Gets the list of densities not used, so we can delete intermediate files."""
-    return list(
-        set(["native"] + atlas_config[atlas]["density_wildcards"]) - set(output_density)
-    )
-
-
-def format_density_help(atlas_config):
-    lines = ["Available output densities per atlas:\n"]
-    for atlas, config in atlas_config.items():
-        if "density_wildcards" in config:
-            densities = ", ".join(config["density_wildcards"])
-            lines.append(f"  {atlas}=[{densities}]")
-    return "\n".join(lines)
-
-
-def validate_output_density(atlas, output_densities, atlas_config):
-    """
-    Validate that each output_density is allowed for the selected atlas.
-
-    Parameters:
-        atlas (str): The name of the selected atlas.
-        output_densities (str or list): One or more densities to validate.
-        atlas_config (dict): Dictionary of atlas options, with allowed densities under ['density_wildcards'].
-
-    Raises:
-        ValueError: If any of the provided densities are invalid.
-    """
-    if isinstance(output_densities, str):
-        output_densities = [output_densities]
-
-    allowed = set(atlas_config[atlas]["density_wildcards"]) | {"native"}
-
-    invalid = [d for d in output_densities if d not in allowed]
-    if invalid:
-        raise ValueError(
-            f"Invalid output_density value(s) for atlas '{atlas}': {invalid}. "
-            f"Allowed values: {sorted(allowed)}"
-        )
-
-
-# helper functions for hippunfold-atlases
-
-
-def git_ls_remote_with_timeout(repo_url: str, timeout: int = 10) -> bool:
-    """
-    Return True if `git ls-remote <repo_url>` succeeds within `timeout` seconds,
-    otherwise False. Does not hang indefinitely.
-    """
-    env = os.environ.copy()
-    env.setdefault("GIT_TERMINAL_PROMPT", "0")
-    try:
-        subprocess.run(
-            ["git", "ls-remote", repo_url],
-            check=True,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-            env=env,
-        )
-        return True
-    except subprocess.TimeoutExpired:
-        print(f"git ls-remote timed out after {timeout}s")
-        return False
-    except subprocess.CalledProcessError as e:
-        print(
-            f"git ls-remote returned non-zero: {(e.stderr or e.stdout or str(e))[:400]}"
-        )
-        return False
-
-
-def sync_atlas_repo():
-    """
-    Ensures the atlas folder is synced from the public GitHub repository using GitPython.
-    """
-    repo_url = "https://github.com/khanlab/hippunfold-atlases.git"
-    atlas_dir = Path(utils.get_download_dir()) / "hippunfold-atlases"
-    internet = git_ls_remote_with_timeout(repo_url)
-
-    branch = ATLAS_REPO_COMMIT
-    try:
-        if atlas_dir.exists() and (atlas_dir / ".git").exists():
-            if internet:
-                repo = Repo(atlas_dir)
-                origin = repo.remotes.origin
-                origin.fetch()
-
-                # Make sure the branch exists locally and tracks remote
-                if branch not in repo.heads:
-                    repo.git.checkout("-b", branch, f"origin/{branch}")
-                else:
-                    repo.git.checkout(branch)
-
-                # Pull latest updates (fast-forward only)
-                repo.git.pull("--ff-only")
-            else:
-                logger.warning(
-                    "WARNING: Git repo not accessible, not updating the existing atlas repository"
-                )
-        else:
-            if not internet:
-                raise ConnectionError(
-                    "Git repo not accessible, error cloning atlas repository"
-                )
-            repo = Repo.clone_from(repo_url, atlas_dir)
-            repo.git.checkout(branch)
-    except GitCommandError as e:
-        logger.error(f"Git error while syncing atlas repository: {e}")
-
-
-def load_atlas_configs(atlas_dirs):
-    """
-    Loads surface atlas configurations from multiple directories.
-
-    Args:
-        atlas_dirs (list of str or Path): List of directories to search for surface atlas.
-        The later directories in the list override the earlier ones.
-
-    Returns:
-        dict: A dictionary where keys are atlas names and values are their configurations.
-    """
-    atlas = {}
-
-    for atlas_dir in atlas_dirs:
-        atlas_path = Path(atlas_dir)
-        if not atlas_path.exists():
-            continue
-
-        for subdir in atlas_path.iterdir():
-            if subdir.is_dir():
-                template_json = subdir / "template_description.json"
-                if template_json.exists():
-                    try:
-                        with open(template_json, "r") as f:
-                            config_data = json.load(f)
-                        atlas[subdir.name.removeprefix("tpl-")] = (
-                            config_data  # Override existing atlas if needed
-                        )
-                    except (json.JSONDecodeError, IOError) as e:
-                        print(f"Warning: Failed to load {template_json}: {e}")
-
-    return atlas
-
-
-def get_atlas_configs():
-    """
-    Gets surface atlas configurations from both the centralized repo and cache directory.
-
-    Returns:
-        dict: Merged atlas configurations, prioritizing user-defined ones.
-    """
-
-    # Sync the atlas repository
-    sync_atlas_repo()
-
-    # Define search locations
-    cache_dir = utils.get_download_dir()
-
-    atlas_dirs = []
-    atlas_dirs.append(Path(cache_dir) / "hippunfold-atlases")
-
-    return load_atlas_configs(atlas_dirs)
+    return list(set(OUTPUT_DENSITIES) - set(output_density))
 
 
 # snakebids plugin definition
@@ -267,7 +95,6 @@ class AtlasConfig(PluginBase):
     """
 
     argument_group: str | None = None
-    atlas_config: dict = attrs.field(factory=get_atlas_configs)
 
     @bidsapp.hookimpl
     def add_cli_arguments(
@@ -282,14 +109,28 @@ class AtlasConfig(PluginBase):
         self.try_add_argument(
             group,
             "--atlas",
-            choices=list(self.atlas_config.keys()),
+            choices=ATLASES,
             action="store",
             type=str,
             dest="atlas",
-            default="multihist7",
+            default=DEFAULT_ATLAS,
             help=(
                 "Select the atlas (unfolded space) to use for subfield labels. (default: %(default)s)"
             ),
+        )
+
+        self.try_add_argument(
+            group,
+            "--output-density",
+            "--output_density",
+            action="store",
+            type=str,
+            dest="output_density",
+            default=DEFAULT_OUTPUT_DENSITY,
+            choices=OUTPUT_DENSITIES,
+            nargs="+",
+            help="Sets the output vertex density for participant-level results. Note: the density refers to the number of vertices in the hipp surface; the dentate has 1/4 the number of vertices.\n"
+            + " (default: %(default)s)",
         )
 
         self.try_add_argument(
@@ -326,21 +167,6 @@ class AtlasConfig(PluginBase):
             ),
         )
 
-        self.try_add_argument(
-            group,
-            "--output-density",
-            "--output_density",
-            action="store",
-            type=str,
-            dest="output_density",
-            default=DEFAULT_OUTPUT_DENSITY,
-            choices=get_all_densities(self.atlas_config),
-            nargs="+",
-            help="Sets the output vertex density for participant-level results. Note: the density refers to the number of vertices in the hipp surface; the dentate has 1/4 the number of vertices.\n"
-            + format_density_help(self.atlas_config)
-            + " (default: %(default)s)",
-        )
-
     @bidsapp.hookimpl
     def update_cli_namespace(self, namespace: dict[str, Any], config: dict[str, Any]):
         """Add atlas to config."""
@@ -360,18 +186,14 @@ class AtlasConfig(PluginBase):
                     "--new_atlas_subfields_from must be specified when using group_create_atlas"
                 )
 
-        validate_output_density(atlas, output_density, self.atlas_config)
-
         config["atlas"] = atlas
         config["new_atlas_name"] = new_atlas_name
         config["new_atlas_subfields_from"] = new_atlas_subfields_from
-        config["atlas_metadata"] = self.atlas_config
         config["output_density"] = output_density
-        config["unfoldreg_density"] = get_unfoldreg_density(self.atlas_config, atlas)
+        config["unfoldreg_density"] = OUTPUT_DENSITIES[-1]
         config["resample_factors"] = DEFAULT_RESAMPLE_FACTORS
         config["density_choices"] = resample_factors_to_densities(
             DEFAULT_RESAMPLE_FACTORS
         )
-        config["unused_density"] = get_unused_densities(
-            self.atlas_config, atlas, output_density
-        )
+        config["unused_density"] = get_unused_densities(output_density)
+        config["atlas_metadata"] = ATLAS_METADATA

--- a/hippunfold/workflow/envs/curl.yaml
+++ b/hippunfold/workflow/envs/curl.yaml
@@ -1,6 +1,0 @@
-name: curl
-channels:
-  - defaults
-dependencies:
-  - python=3.9
-  - curl

--- a/hippunfold/workflow/profiles/default/config.yaml
+++ b/hippunfold/workflow/profiles/default/config.yaml
@@ -1,1 +1,1 @@
-use-conda: False
+use-conda: True

--- a/hippunfold/workflow/profiles/default/config.yaml
+++ b/hippunfold/workflow/profiles/default/config.yaml
@@ -1,1 +1,1 @@
-use-conda: True
+use-conda: False

--- a/hippunfold/workflow/rules/atlas_gen.smk
+++ b/hippunfold/workflow/rules/atlas_gen.smk
@@ -446,7 +446,7 @@ rule gen_unfold_atlas_mesh_flip:
             resample="{resample}",
             space="unfold",
             hemi="R",
-            suffix="{surfname,midthickness|inner|outer}.surf.gii",
+            suffix="{surfname}.surf.gii",
         ),
     params:
         z_level=get_unfold_z_level,
@@ -1059,3 +1059,6 @@ rule write_template_json:
         ),
     script:
         "../scripts/write_template_json.py"
+
+
+# TODO add rule to create zip file of new atlas and push to zenodo (need to add CLI to enable this)

--- a/hippunfold/workflow/rules/common.smk
+++ b/hippunfold/workflow/rules/common.smk
@@ -24,7 +24,7 @@ def bids_log(rule_name, **kwargs):
 
 
 def get_atlas_dir():
-    return Path(utils.get_download_dir()) / "atlas"
+    return Path(utils.get_download_dir()) / "atlases"
 
 
 def expand_hemi():

--- a/hippunfold/workflow/rules/common.smk
+++ b/hippunfold/workflow/rules/common.smk
@@ -24,7 +24,7 @@ def bids_log(rule_name, **kwargs):
 
 
 def get_atlas_dir():
-    return Path(utils.get_download_dir()) / "hippunfold-atlases"
+    return Path(utils.get_download_dir()) / "atlas"
 
 
 def expand_hemi():

--- a/hippunfold/workflow/rules/download.smk
+++ b/hippunfold/workflow/rules/download.smk
@@ -5,6 +5,7 @@ download_dir = utils.get_download_dir()
 
 
 rule download_extract_template:
+    """Note: OSF urls don't seem to be supported with snakemake storage plugin"""
     params:
         url=lambda wildcards: config["resource_urls"]["template"][wildcards.template],
     output:

--- a/hippunfold/workflow/rules/download.smk
+++ b/hippunfold/workflow/rules/download.smk
@@ -35,7 +35,7 @@ rule cp_atlas_surf_gii:
         unzip_dir=Path(download_dir) / "atlases_dl" / "tpl-{atlas}",
     params:
         path=lambda wildcards, input: bids_atlas(
-            root=input.unzip_dir,
+            root=Path(input.unzip_dir).parent,
             template=wildcards.atlas,
             hemi=wildcards.hemi,
             label=wildcards.label,
@@ -62,7 +62,7 @@ rule cp_atlas_metric_gii:
         unzip_dir=Path(download_dir) / "atlases_dl" / "tpl-{atlas}",
     params:
         path=lambda wildcards, input: bids_atlas(
-            root=input.unzip_dir,
+            root=Path(input.unzip_dir).parent,
             template=wildcards.atlas,
             hemi=wildcards.hemi,
             label=wildcards.label,

--- a/hippunfold/workflow/rules/download.smk
+++ b/hippunfold/workflow/rules/download.smk
@@ -16,14 +16,16 @@ rule download_extract_template:
 
 
 rule download_surf_template_atlas:
-    params:
-        url=lambda wildcards: config["resource_urls"]["atlas"][wildcards.atlas],
+    input:
+        zip_file=lambda wildcards: storage(
+            config["resource_urls"]["atlas"][wildcards.atlas]
+        ),
     output:
         unzip_dir=temp(directory(Path(download_dir) / "atlas_dl" / "{atlas}")),
     shadow:
         "minimal"
-    script:
-        "../scripts/download.py"
+    shell:
+        "unzip {input} -d {output}"
 
 
 rule cp_atlas_surf_gii:

--- a/hippunfold/workflow/rules/download.smk
+++ b/hippunfold/workflow/rules/download.smk
@@ -15,6 +15,69 @@ rule download_extract_template:
         "../scripts/download.py"
 
 
+rule download_surf_template_atlas:
+    params:
+        url=lambda wildcards: config["resource_urls"]["atlas"][wildcards.atlas],
+    output:
+        unzip_dir=temp(directory(Path(download_dir) / "atlas_dl" / "{atlas}")),
+    shadow:
+        "minimal"
+    script:
+        "../scripts/download.py"
+
+
+rule cp_atlas_surf_gii:
+    input:
+        unzip_dir=Path(download_dir) / "atlas_dl" / "{atlas}",
+    params:
+        path=lambda wildcards, input: bids_atlas(
+            root=input.unzip_dir,
+            template=wildcards.atlas,
+            hemi=wildcards.hemi,
+            label=wildcards.label,
+            den=wildcards.density,
+            space=wildcards.space,
+            suffix=f"{wildcards.surf_name}.surf.gii",
+        ),
+    output:
+        atlas_file=bids_atlas(
+            root=get_atlas_dir(),
+            template="{atlas}",
+            hemi="{hemi}",
+            label="{label}",
+            den="{density}",
+            space="{space}",
+            suffix="{surf_name}.surf.gii",
+        ),
+    shell:
+        "cp {params.path} {output}"
+
+
+rule cp_atlas_shape_gii:
+    input:
+        unzip_dir=Path(download_dir) / "atlas_dl" / "{atlas}",
+    params:
+        path=lambda wildcards, input: bids_atlas(
+            root=input.unzip_dir,
+            template=wildcards.atlas,
+            hemi=wildcards.hemi,
+            label=wildcards.label,
+            den=wildcards.density,
+            suffix=f"{wildcards.metricname}.{wildcards.metrictype}.gii",
+        ),
+    output:
+        atlas_file=bids_atlas(
+            root=get_atlas_dir(),
+            template="{atlas}",
+            hemi="{hemi}",
+            label="{label}",
+            den="{density}",
+            suffix="{metricname}.{metrictype}.gii",
+        ),
+    shell:
+        "cp {params.path} {output}"
+
+
 ## unpack template
 # this is used in both shape_inject.smk and templateseg.smk, so instead of having redundant rules I will simply apply them hemisphere
 # Template-based segmentation supports templates that have only a single hemisphere

--- a/hippunfold/workflow/rules/download.smk
+++ b/hippunfold/workflow/rules/download.smk
@@ -22,6 +22,8 @@ rule download_surf_template_atlas:
         ),
     output:
         unzip_dir=temp(directory(Path(download_dir) / "atlases_dl" / "tpl-{atlas}")),
+    wildcard_constraints:
+        atlas="|".join(config["builtin_atlases"]),
     shadow:
         "minimal"
     shell:

--- a/hippunfold/workflow/rules/download.smk
+++ b/hippunfold/workflow/rules/download.smk
@@ -21,7 +21,7 @@ rule download_surf_template_atlas:
             config["resource_urls"]["atlas"][wildcards.atlas]
         ),
     output:
-        unzip_dir=temp(directory(Path(download_dir) / "atlas_dl" / "{atlas}")),
+        unzip_dir=temp(directory(Path(download_dir) / "atlases_dl" / "tpl-{atlas}")),
     shadow:
         "minimal"
     shell:
@@ -30,7 +30,7 @@ rule download_surf_template_atlas:
 
 rule cp_atlas_surf_gii:
     input:
-        unzip_dir=Path(download_dir) / "atlas_dl" / "{atlas}",
+        unzip_dir=Path(download_dir) / "atlases_dl" / "tpl-{atlas}",
     params:
         path=lambda wildcards, input: bids_atlas(
             root=input.unzip_dir,
@@ -55,9 +55,9 @@ rule cp_atlas_surf_gii:
         "cp {params.path} {output}"
 
 
-rule cp_atlas_shape_gii:
+rule cp_atlas_metric_gii:
     input:
-        unzip_dir=Path(download_dir) / "atlas_dl" / "{atlas}",
+        unzip_dir=Path(download_dir) / "atlases_dl" / "tpl-{atlas}",
     params:
         path=lambda wildcards, input: bids_atlas(
             root=input.unzip_dir,

--- a/hippunfold/workflow/rules/nnunet.smk
+++ b/hippunfold/workflow/rules/nnunet.smk
@@ -60,19 +60,16 @@ def get_model_dir():
 
 
 rule download_nnunet_model:
-    params:
-        url=(
+    input:
+        url=storage(
             config["resource_urls"]["nnunet_model"][config["force_nnunet_model"]]
             if config["force_nnunet_model"]
             else config["resource_urls"]["nnunet_model"][config["modality"]]
         ),
-        model_dir=Path(download_dir) / "model",
     output:
         model_tar=temp(get_model_tar()),
-    conda:
-        "../envs/curl.yaml"
     shell:
-        "mkdir -p {params.model_dir} && curl -L https://{params.url} -o {output}"
+        "cp {input} {output}"
 
 
 def parse_task_from_dir(wildcards, input):

--- a/pixi.lock
+++ b/pixi.lock
@@ -28,6 +28,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bcrypt-5.0.0-py312h868fb18_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bids-validator-1.14.7.post0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bidsschematools-1.0.14-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/blinker-1.9.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boltons-25.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boutiques-0.5.30-pyhd8ed1ab_0.conda
@@ -260,6 +261,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/nlohmann_json-abi-3.12.0-h0f90c79_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/num2words-0.5.14-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.1-py312h33ff503_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/opencl-headers-2025.06.13-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.6.0-hc22cd8d_0.conda
@@ -298,6 +300,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.11.7-pyh3cfb1c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.33.2-py312h680f630_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.11.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pynacl-1.6.2-py312h4c3975b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.3-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
@@ -317,6 +320,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/reproc-14.2.5.post0-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/reproc-cpp-14.2.5.post0-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-oauthlib-1.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/reretry-0.11.8-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.1.0-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py312h868fb18_0.conda
@@ -343,6 +347,7 @@ environments:
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-report-plugins-1.2.0-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-storage-plugins-4.2.2-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-minimal-9.9.0-pyhdfd78af_0.tar.bz2
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-storage-plugin-http-0.3.0-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-2.0.46-py312h5253ce2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.50.4-hbc0de68_0.conda
@@ -366,6 +371,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ubiquerg-0.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-17.0.0-py312h4c3975b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/unzip-6.0-hb03c661_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/utfcpp-4.0.6-h005c6e1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/veracitools-0.1.3-py_0.tar.bz2
@@ -447,6 +453,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/bids-validator-1.14.7.post0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/bidsschematools-1.0.14-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/black-24.10.0-py312h7900ff3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/blinker-1.9.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boltons-25.0.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boutiques-0.5.30-pyhd8ed1ab_0.conda
@@ -690,6 +697,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/nlohmann_json-3.11.3-he02047a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/num2words-0.5.14-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.3.2-py312h33ff503_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.3-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/opencl-headers-2025.06.13-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openh264-2.6.0-hc22cd8d_0.conda
@@ -733,6 +741,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyflakes-2.4.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pygraphviz-1.14-py312hdfa1987_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.11.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pylint-2.17.7-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pynacl-1.5.0-py312h66e93f0_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.2.3-pyhe01879c_2.conda
@@ -756,6 +765,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/reproc-14.2.5.post0-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/reproc-cpp-14.2.5.post0-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-oauthlib-1.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/reretry-0.11.8-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.1.0-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.27.0-py312h868fb18_0.conda
@@ -783,6 +793,7 @@ environments:
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-report-plugins-1.2.0-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-storage-plugins-4.2.2-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-minimal-9.9.0-pyhdfd78af_0.tar.bz2
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-storage-plugin-http-0.3.0-pyhdfd78af_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlalchemy-2.0.43-py312h4c3975b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.50.4-hbc0de68_0.conda
@@ -808,6 +819,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ubiquerg-0.8.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-16.0.0-py312h66e93f0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/unzip-6.0-hb03c661_4.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/utfcpp-4.0.6-h005c6e1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/veracitools-0.1.3-py_0.tar.bz2
@@ -866,16 +878,25 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/adwaita-icon-theme-48.1-unix_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/argparse-dataclass-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/astroid-2.15.8-py312h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/at-spi2-atk-2.38.0-h0630a04_3.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/at-spi2-core-2.40.3-h0630a04_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/atk-1.0-2.38.0-h04ea711_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.3.0-py312h90b7ffd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/black-24.10.0-py312h7900ff3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/blinker-1.9.0-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.2.0-py312hdb49522_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.8.3-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-h3394656_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.1.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py312h35888ee_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.2.1-pyh707e725_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/configargparse-1.7.1-pyhe01879c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-45.0.7-py312hee9fe19_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h3c4dab8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dill-0.4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/epoxy-1.5.10-h166bdaf_1.tar.bz2
@@ -896,9 +917,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphviz-13.1.2-h87b6fe6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gtk3-3.24.43-h0c6a113_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gts-0.7.6-h977cf35_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-11.4.1-h15599e2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hicolor-icon-theme-0.17-ha770c72_2.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/iniconfig-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/isort-5.13.2-pyhd8ed1ab_1.conda
@@ -941,6 +966,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/mccabe-0.6.1-py_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/mypy_extensions-1.1.0-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.2-h26f9b46_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/packaging-25.0-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pango-1.56.4-hadf4263_0.conda
@@ -953,23 +979,35 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/poethepoet-0.10.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.8.0-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyflakes-2.4.0-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pygraphviz-1.14-py312hdfa1987_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.11.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pylint-2.17.7-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-console-scripts-1.4.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.11-h9e4cc4f_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.12-8_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/requests-oauthlib-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/reretry-0.11.8-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
       - conda: https://conda.anaconda.org/bioconda/noarch/snakefmt-0.10.2-pyhdfd78af_0.tar.bz2
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-common-1.22.0-pyhd4c3c12_0.conda
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-storage-plugins-4.3.2-pyhd4c3c12_0.conda
+      - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-storage-plugin-http-0.3.0-pyhdfd78af_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/throttler-1.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_hd72426e_102.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toml-0.10.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomlkit-0.13.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.14.1-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/unzip-6.0-hb03c661_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wayland-1.24.0-h3e06ad9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.17.3-py312h4c3975b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xkeyboard-config-2.45-hb9d3cd8_0.conda
@@ -1181,6 +1219,17 @@ packages:
   - pkg:pypi/argparse-dataclass?source=hash-mapping
   size: 12203
   timestamp: 1691002812997
+- conda: https://conda.anaconda.org/conda-forge/noarch/argparse-dataclass-2.0.0-pyhd8ed1ab_1.conda
+  sha256: fd512bde81be7f942e1efb54c6a7305c16375347ccacf9375ada70cdc0f4f0d3
+  md5: 3c0e753fd317fa10d34020a2bc8add8e
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/argparse-dataclass?source=hash-mapping
+  size: 12806
+  timestamp: 1764079623900
 - conda: https://conda.anaconda.org/conda-forge/noarch/arrow-1.3.0-pyhd8ed1ab_1.conda
   sha256: c4b0bdb3d5dee50b60db92f99da3e4c524d5240aafc0a5fcc15e45ae2d1a3cd1
   md5: 46b53236fdd990271b03c3978d4218a9
@@ -1283,6 +1332,20 @@ packages:
   - pkg:pypi/attrs?source=hash-mapping
   size: 57181
   timestamp: 1741918625732
+- conda: https://conda.anaconda.org/conda-forge/linux-64/backports.zstd-1.3.0-py312h90b7ffd_0.conda
+  sha256: d77a24be15e283d83214121428290dbe55632a6e458378205b39c550afa008cf
+  md5: 5b8c55fed2e576dde4b0b33693a4fdb1
+  depends:
+  - python
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - python_abi 3.12.* *_cp312
+  - zstd >=1.5.7,<1.6.0a0
+  license: BSD-3-Clause AND MIT AND EPL-2.0
+  purls:
+  - pkg:pypi/backports-zstd?source=hash-mapping
+  size: 237970
+  timestamp: 1767045004512
 - conda: https://conda.anaconda.org/conda-forge/linux-64/bcrypt-4.3.0-py312h680f630_1.conda
   sha256: 13ed7f3ad12429688d4cbd88715d78ffb46c5c953e12b7f3226a4335f01766e5
   md5: acb276847c5bb9eaa38ab8a205fa5ff8
@@ -1358,6 +1421,17 @@ packages:
   - pkg:pypi/black?source=hash-mapping
   size: 390571
   timestamp: 1728503839694
+- conda: https://conda.anaconda.org/conda-forge/noarch/blinker-1.9.0-pyhff2d567_0.conda
+  sha256: f7efd22b5c15b400ed84a996d777b6327e5c402e79e3c534a7e086236f1eb2dc
+  md5: 42834439227a4551b939beeeb8a4b085
+  depends:
+  - python >=3.9
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/blinker?source=hash-mapping
+  size: 13934
+  timestamp: 1731096548765
 - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
   sha256: e7af5d1183b06a206192ff440e08db1c4e8b2ca1f8376ee45fb2f3a85d4ee45d
   md5: 2c2fae981fd2afd00812c92ac47d023d
@@ -1566,6 +1640,16 @@ packages:
   - pkg:pypi/certifi?source=compressed-mapping
   size: 158692
   timestamp: 1754231530168
+- conda: https://conda.anaconda.org/conda-forge/noarch/certifi-2026.1.4-pyhd8ed1ab_0.conda
+  sha256: 110338066d194a715947808611b763857c15458f8b3b97197387356844af9450
+  md5: eacc711330cd46939f66cd401ff9c44b
+  depends:
+  - python >=3.10
+  license: ISC
+  purls:
+  - pkg:pypi/certifi?source=compressed-mapping
+  size: 150969
+  timestamp: 1767500900768
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py312h06ac9bb_0.conda
   sha256: cba6ea83c4b0b4f5b5dc59cb19830519b28f95d7ebef7c9c5cf1c14843621457
   md5: a861504bbea4161a9170b85d4d2be840
@@ -1582,6 +1666,22 @@ packages:
   - pkg:pypi/cffi?source=hash-mapping
   size: 294403
   timestamp: 1725560714366
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py312h35888ee_0.conda
+  sha256: f9e906b2cb9ae800b5818259472c3f781b14eb1952e867ac5c1f548e92bf02d9
+  md5: 60b9cd087d22272885a6b8366b1d3d43
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libffi >=3.4.6,<3.5.0a0
+  - libgcc >=14
+  - pycparser
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/cffi?source=hash-mapping
+  size: 296986
+  timestamp: 1758716192805
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-2.0.0-py312h460c074_1.conda
   sha256: 7dafe8173d5f94e46cf9cd597cc8ff476a8357fbbd4433a8b5697b2864845d9c
   md5: 648ee28dcd4e07a1940a17da62eccd40
@@ -1609,6 +1709,17 @@ packages:
   - pkg:pypi/charset-normalizer?source=hash-mapping
   size: 51033
   timestamp: 1754767444665
+- conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.4-pyhd8ed1ab_0.conda
+  sha256: b32f8362e885f1b8417bac2b3da4db7323faa12d5db62b7fd6691c02d60d6f59
+  md5: a22d1fd9bf98827e280a02875d9a007a
+  depends:
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/charset-normalizer?source=hash-mapping
+  size: 50965
+  timestamp: 1760437331772
 - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.2.1-pyh707e725_0.conda
   sha256: 8aee789c82d8fdd997840c952a586db63c6890b00e88c4fb6e80a38edd5f51c0
   md5: 94b550b8d3a614dbd326af798c7dfb40
@@ -2005,6 +2116,24 @@ packages:
   - pkg:pypi/cryptography?source=compressed-mapping
   size: 1653373
   timestamp: 1754473134017
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-45.0.7-py312hee9fe19_1.conda
+  sha256: 86b5390090e8b6d236930f7fe64f98fa3b576d0e5c660fa483fdfcb31aa9ece7
+  md5: 8281f9bc2a0be122924f717abb4aff65
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - cffi >=1.12
+  - libgcc >=14
+  - openssl >=3.5.2,<4.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __glibc >=2.17
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  purls:
+  - pkg:pypi/cryptography?source=hash-mapping
+  size: 1652920
+  timestamp: 1756843727188
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-46.0.3-py312ha4b625e_1.conda
   sha256: 28dd9ae4bf7913a507e08ccd13788f0abe75557831095244e487bda2c474554f
   md5: a42f7c8a15d53cdb6738ece5bd745d13
@@ -2866,6 +2995,20 @@ packages:
   - pkg:pypi/h2?source=hash-mapping
   size: 53888
   timestamp: 1738578623567
+- conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
+  sha256: 84c64443368f84b600bfecc529a1194a3b14c3656ee2e832d15a20e0329b6da3
+  md5: 164fc43f0b53b6e3a7bc7dce5e4f1dc9
+  depends:
+  - python >=3.10
+  - hyperframe >=6.1,<7
+  - hpack >=4.1,<5
+  - python
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/h2?source=hash-mapping
+  size: 95967
+  timestamp: 1756364871835
 - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-11.0.0-h76408a6_0.conda
   sha256: 9d33201d3e12a61d4ea4b1252a3468afb18b11a418f095dceffdf09bc6792f59
   md5: 347cb348bfc8d77062daee11c326e518
@@ -2947,7 +3090,7 @@ packages:
 - pypi: ./
   name: hippunfold
   version: 1.5.2rc2
-  sha256: 07332e699e21a8e567a29b097ffea892bd203d6a745055e2d24ad5b39b0823f2
+  sha256: f6ef69c2dc25b6f8564ff5ec494a4e1c00e2e9d88eb48bafa8ab098a43ddb736
   requires_python: '>=3.11,<3.13'
   editable: true
 - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
@@ -3007,6 +3150,17 @@ packages:
   - pkg:pypi/idna?source=hash-mapping
   size: 49765
   timestamp: 1733211921194
+- conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.11-pyhd8ed1ab_0.conda
+  sha256: ae89d0299ada2a3162c2614a9d26557a92aa6a77120ce142f8e0109bbf0342b0
+  md5: 53abe63df7e10a6ba605dc5f9f961d36
+  depends:
+  - python >=3.10
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/idna?source=hash-mapping
+  size: 50721
+  timestamp: 1760286526795
 - conda: https://conda.anaconda.org/conda-forge/linux-64/immutables-0.21-py312h4c3975b_2.conda
   sha256: 33f87bd1b9a48c208919641a878541c13316afa1cfabea97c534227d52904a0b
   md5: 4cf92a9dd8712cdde044fb56be498bd4
@@ -5613,6 +5767,20 @@ packages:
   - pkg:pypi/numpy?source=compressed-mapping
   size: 8757015
   timestamp: 1768085678045
+- conda: https://conda.anaconda.org/conda-forge/noarch/oauthlib-3.3.1-pyhd8ed1ab_0.conda
+  sha256: dfa8222df90736fa13f8896f5a573a50273af8347542d412c3bd1230058e56a5
+  md5: d4f3f31ee39db3efecb96c0728d4bdbf
+  depends:
+  - blinker
+  - cryptography
+  - pyjwt >=1.0.0
+  - python >=3.9
+  license: BSD-3-Clause
+  license_family: BSD
+  purls:
+  - pkg:pypi/oauthlib?source=hash-mapping
+  size: 102059
+  timestamp: 1750415349440
 - conda: https://conda.anaconda.org/conda-forge/linux-64/ocl-icd-2.3.3-hb9d3cd8_0.conda
   sha256: 2254dae821b286fb57c61895f2b40e3571a070910fdab79a948ff703e1ea807b
   md5: 56f8947aa9d5cf37b0b3d43b83f34192
@@ -6415,6 +6583,19 @@ packages:
   - pkg:pypi/pygraphviz?source=hash-mapping
   size: 146237
   timestamp: 1753611463756
+- conda: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.11.0-pyhd8ed1ab_0.conda
+  sha256: ac605d7fa239f78c508b47f2a0763236eef8d52b53852b84d784b598f92a1573
+  md5: f9517d2fe1501919d7a236aba73409bb
+  depends:
+  - python >=3.10
+  constrains:
+  - cryptography >=3.4.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pyjwt?source=compressed-mapping
+  size: 30144
+  timestamp: 1769858771741
 - conda: https://conda.anaconda.org/conda-forge/noarch/pylint-2.17.7-pyhd8ed1ab_0.conda
   sha256: 1b1b60cf022828ac0a1ae88d4cdf16fb9b4d74b3e6d5cf9fc35cccc3328b53f9
   md5: 3cab6aee60038b3f621bce3e50f52bed
@@ -6912,6 +7093,36 @@ packages:
   - pkg:pypi/requests?source=hash-mapping
   size: 59407
   timestamp: 1749498221996
+- conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhcf101f3_1.conda
+  sha256: 7813c38b79ae549504b2c57b3f33394cea4f2ad083f0994d2045c2e24cb538c5
+  md5: c65df89a0b2e321045a9e01d1337b182
+  depends:
+  - python >=3.10
+  - certifi >=2017.4.17
+  - charset-normalizer >=2,<4
+  - idna >=2.5,<4
+  - urllib3 >=1.21.1,<3
+  - python
+  constrains:
+  - chardet >=3.0.2,<6
+  license: Apache-2.0
+  license_family: APACHE
+  purls:
+  - pkg:pypi/requests?source=compressed-mapping
+  size: 63602
+  timestamp: 1766926974520
+- conda: https://conda.anaconda.org/conda-forge/noarch/requests-oauthlib-1.4.0-pyhd8ed1ab_0.conda
+  sha256: 909ec1510bbb6fad9276534352025f428050a4deeea86e68d61c8c580938ac82
+  md5: a55b220de8970208f583e38639cfbecc
+  depends:
+  - oauthlib >=3.0.0
+  - python >=3.4
+  - requests >=2.0.0
+  license: ISC
+  purls:
+  - pkg:pypi/requests-oauthlib?source=hash-mapping
+  size: 25757
+  timestamp: 1710149693493
 - conda: https://conda.anaconda.org/conda-forge/noarch/reretry-0.11.8-pyhd8ed1ab_1.conda
   sha256: f010d25e0ab452c0339a42807c84316bf30c5b8602b9d74d566abf1956d23269
   md5: b965b0dfdb3c89966a6a25060f73aa67
@@ -7358,6 +7569,20 @@ packages:
   - pkg:pypi/snakemake-interface-common?source=hash-mapping
   size: 20396
   timestamp: 1753346658467
+- conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-common-1.22.0-pyhd4c3c12_0.conda
+  sha256: d13802cb086c1b6be2c4e903e01f946fc973436e6100514169df82e537166bce
+  md5: e9bb00d8c7d26a5cd220d3d73bee45fb
+  depends:
+  - argparse-dataclass >=2.0.0
+  - configargparse >=1.7
+  - packaging >=24.0,<26.0
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/snakemake-interface-common?source=hash-mapping
+  size: 21989
+  timestamp: 1759253200205
 - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-executor-plugins-9.3.9-pyhdfd78af_0.tar.bz2
   sha256: fe84cb2f9dbae898c9aa3f5a44b9f4d150cc05b5d0aa21561c5f9207c7184b23
   md5: e75b9c422bcc3c9b52679dedb84f3b71
@@ -7409,6 +7634,21 @@ packages:
   - pkg:pypi/snakemake-interface-storage-plugins?source=hash-mapping
   size: 20071
   timestamp: 1753822177984
+- conda: https://conda.anaconda.org/bioconda/noarch/snakemake-interface-storage-plugins-4.3.2-pyhd4c3c12_0.conda
+  sha256: 016d5af7a69740830d6b9438d2122778d5d7a599cc6aa6d65e366bc9a4176473
+  md5: b894c6a2d0612da952c9989ac7a22d16
+  depends:
+  - python >=3.11.0,<4.0.0
+  - reretry >=0.11.8,<0.12.0
+  - snakemake-interface-common >=1.12.0,<2.0.0
+  - throttler >=1.2.2,<2.0.0
+  - wrapt >=1.15.0,<2.0.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/snakemake-interface-storage-plugins?source=hash-mapping
+  size: 21574
+  timestamp: 1764856126551
 - conda: https://conda.anaconda.org/bioconda/noarch/snakemake-minimal-9.9.0-pyhdfd78af_0.tar.bz2
   sha256: c8569a02cf6f53efaa702b1328dc64bdc6d319fc92d728512e058f6d47b6da90
   md5: 3a868dce9d8aac690aecf72738dcbccf
@@ -7448,6 +7688,20 @@ packages:
   - pkg:pypi/snakemake?source=hash-mapping
   size: 885848
   timestamp: 1753812853191
+- conda: https://conda.anaconda.org/bioconda/noarch/snakemake-storage-plugin-http-0.3.0-pyhdfd78af_0.tar.bz2
+  sha256: 0fe598fee2cbb25ce5a6bd073a3514f36adde5e6e3e1ed486c7066e742286492
+  md5: 269943ac6637718947763b4f989710fc
+  depends:
+  - python >=3.11.0,<4.0.0
+  - requests >=2.31.0,<3.0.0
+  - requests-oauthlib >=1.3.1,<2.0.0
+  - snakemake-interface-common >=1.14.0,<2.0.0
+  - snakemake-interface-storage-plugins >=4.1.0,<5.0.0
+  license: MIT
+  purls:
+  - pkg:pypi/snakemake-storage-plugin-http?source=hash-mapping
+  size: 13546
+  timestamp: 1742824892142
 - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_0.conda
   sha256: 8b8acbde6814d1643da509e11afeb6bb30eb1e3004cf04a7c9ae43e9b097f063
   md5: 3d8da0248bdae970b4ade636a104b7f5
@@ -7779,6 +8033,16 @@ packages:
   - pkg:pypi/unicodedata2?source=hash-mapping
   size: 408399
   timestamp: 1763054875733
+- conda: https://conda.anaconda.org/conda-forge/linux-64/unzip-6.0-hb03c661_4.conda
+  sha256: 489ee14dcc1080e45d07531e89b1c690a8df68ca6a817ade536e6ef4cdc77b9e
+  md5: 7f58240fa4cd5b42607606333cf8b550
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  license: LicenseRef-BSD-like
+  purls: []
+  size: 146901
+  timestamp: 1754913060109
 - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
   sha256: 4fb9789154bd666ca74e428d973df81087a697dbb987775bc3198d2215f240f8
   md5: 436c165519e140cb08d246a4472a9d6a
@@ -7794,6 +8058,21 @@ packages:
   - pkg:pypi/urllib3?source=hash-mapping
   size: 101735
   timestamp: 1750271478254
+- conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.3-pyhd8ed1ab_0.conda
+  sha256: af641ca7ab0c64525a96fd9ad3081b0f5bcf5d1cbb091afb3f6ed5a9eee6111a
+  md5: 9272daa869e03efe68833e3dc7a02130
+  depends:
+  - backports.zstd >=1.0.0
+  - brotli-python >=1.2.0
+  - h2 >=4,<5
+  - pysocks >=1.5.6,<2.0,!=1.5.7
+  - python >=3.10
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/urllib3?source=hash-mapping
+  size: 103172
+  timestamp: 1767817860341
 - conda: https://conda.anaconda.org/conda-forge/linux-64/utfcpp-4.0.6-h005c6e1_0.conda
   sha256: ec540ff477cd6d209b98f9b201e9c440908ea3a8b62e9e02dd12fcb60fff6d08
   md5: 9464e297fa2bf08030c65a54342b48c3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,10 @@ multi_line_output = 3
 [tool.pixi.pypi-dependencies]
 hippunfold = { path = ".", editable = true }
 
+[tool.pixi.dependencies]
+snakemake-storage-plugin-http = ">=0.3.0,<0.4"
+unzip = ">=6.0,<7"
+
 
 [tool.pixi.feature.dev.tasks]
 quality_check = "isort hippunfold/*.py hippunfold/plugins/*.py -c && black hippunfold --check && snakefmt hippunfold --check"


### PR DESCRIPTION
- atlases have used a git repo (since the atlas plugin, and group_create_atlas workflow) but this complicates things and has led to issues syncing
- this PR simplifies this by removing the git repo and instead using the approach we use for other workflow resources (like registration templates, nnunet models), that is, provide a url to the package, and download it in the workflow
- one improvement while doing this is to replace the custom download scripts/rules with snakemake's built-in storage plugins
- pixi dependencies have been added to enable this (for unzip and snakemake-http-storage-plugin) - TODO: should make sure these are used for conda builds too

- a mechanism for custom atlases is still supported by having them simply read from the cache dir (ie where they are generated).. some logic was added to ensure only built-ins have download-rule dependencies to avoid conflicts
