### PR TITLE
Adds the maguire_T2w model to the dev-v2.0.0 branch

### DIFF
--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -251,6 +251,7 @@ parse_args:
       - neonateT12w_v2
       - ADNI_T1w_v1
       - neonate_synthseg
+      - maguire_T2w
 
   --enable-bids-validation:
     help: |

--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -494,7 +494,7 @@ nnunet_models:
   maguire_T2w:
     url: https://zenodo.org/records/18432751/files/Dataset001_HippUnfoldMag.nnUNetTrainer__nnUNetPlans__3d_fullres.tar.gz
     arch_version: nnunet_v2
-    dataset_id: 101
+    dataset_id: '001'
     configuration: 3d_fullres
     trainer: nnUNetTrainer
     plans: nnUNetPlans

--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -490,7 +490,14 @@ nnunet_models:
     arch_version: synthseg_v2
     checkpoint: last.ckpt
 
-
+  maguire_T2w:
+    url: https://zenodo.org/records/18432751/files/Dataset001_HippUnfoldMag.nnUNetTrainer__nnUNetPlans__3d_fullres.tar.gz
+    arch_version: nnunet_v2
+    dataset_id: 101
+    configuration: 3d_fullres
+    trainer: nnUNetTrainer
+    plans: nnUNetPlans
+    checkpoint: checkpoint_best.pth
 
 #these will be downloaded to ~/.cache/hippunfold
 resource_urls:


### PR DESCRIPTION
Adds in maguire_T2w model trained on high-res T2w data from the Maguire (Clark et al) dataset. (note: also being added in to v1 master in #542)