### PR TITLE
Add options for parameterizing inner/outer image registration 

### DIFF
--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -253,6 +253,23 @@ parse_args:
       - neonate_synthseg
       - maguire_T2w
 
+  --inner_outer_reg_method:
+    help: |
+      Image registration method to use for the image registration to warp midthickness to 
+      inner and outer surfaces.
+    choices: 
+      - greedy
+      - syn
+    default: greedy
+
+  --inner_outer_reg_smoothing:
+    help: |
+      Variance of the Gaussian used to smooth the update field (or gradient step)
+      (in units of voxels) for the image registration to warp midthickness to 
+      inner and outer surfaces. Default value in ANTS is 3. Note for greedy, 
+      the square-root is taken to obtain the sigma.
+    default: 3.0
+
   --enable-bids-validation:
     help: |
       Enable validation of BIDS dataset. BIDS validation would be performed

--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -263,10 +263,9 @@ parse_args:
 
   --inner_outer_reg_smoothing:
     help: |
-      Variance of the Gaussian used to smooth the update field (or gradient step)
-      (in units of voxels) for the image registration to warp midthickness to 
-      inner and outer surfaces. Default value in ANTS is 3. Note for greedy, 
-      the square-root is taken to obtain the sigma.
+      Update-field smoothing variance (vox^2) used by inner/outer image registration.
+      For greedy, sqrt(variance) is used as the Gaussian sigma passed to `greedy -s`.
+      For SyN, the value is passed as the updateFieldVariance in `antsRegistration --transform SyN[...]`.
     default: 3.0
 
   --enable-bids-validation:

--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -255,8 +255,7 @@ parse_args:
 
   --inner_outer_reg_method:
     help: |
-      Image registration method to use for the image registration to warp midthickness to 
-      inner and outer surfaces.
+      Image registration method used to warp midthickness to the inner and outer surfaces.
     choices: 
       - greedy
       - syn

--- a/hippunfold/workflow/rules/inner_outer_surf.smk
+++ b/hippunfold/workflow/rules/inner_outer_surf.smk
@@ -131,23 +131,25 @@ rule register_midthickness_syn:
         "minimal"
     shell:
         r"""
-        tmp_prefix=ants_midthickness
+        (
+            tmp_prefix=ants_midthickness
 
-        antsRegistration \
-            --dimensionality 3 \
-            --float 1 \
-            --interpolation Linear \
-            --use-histogram-matching 0 \
-            --transform SyN[{params.syn_gradient_step},{params.syn_update_field_variance},{params.syn_total_field_variance}] \
-            --metric {params.metric}[{input.fixed},{input.moving},{params.metric_weight},{params.radius}] \
-            --convergence [{params.convergence},{params.convergence_thresh},{params.convergence_window}] \
-            --shrink-factors {params.shrink_factors} \
-            --smoothing-sigmas {params.smoothing_sigmas} \
-            --output [${{tmp_prefix}},${{tmp_prefix}}Warped.nii.gz] \
-            --verbose 1 
+            ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS={threads} antsRegistration \
+                --dimensionality 3 \
+                --float 1 \
+                --interpolation Linear \
+                --use-histogram-matching 0 \
+                --transform SyN[{params.syn_gradient_step},{params.syn_update_field_variance},{params.syn_total_field_variance}] \
+                --metric {params.metric}[{input.fixed},{input.moving},{params.metric_weight},{params.radius}] \
+                --convergence [{params.convergence},{params.convergence_thresh},{params.convergence_window}] \
+                --shrink-factors {params.shrink_factors} \
+                --smoothing-sigmas {params.smoothing_sigmas} \
+                --output [${{tmp_prefix}},${{tmp_prefix}}Warped.nii.gz] \
+                --verbose 1
 
-        mv ${{tmp_prefix}}0Warp.nii.gz {output.warp}
-        mv ${{tmp_prefix}}0InverseWarp.nii.gz {output.invwarp}
+            mv ${{tmp_prefix}}0Warp.nii.gz {output.warp}
+            mv ${{tmp_prefix}}0InverseWarp.nii.gz {output.invwarp}
+        ) &> {log}
         """
 
 

--- a/hippunfold/workflow/rules/inner_outer_surf.smk
+++ b/hippunfold/workflow/rules/inner_outer_surf.smk
@@ -100,7 +100,9 @@ rule register_midthickness:
             to="{inout}",
         ),
     shell:
-        "greedy -threads {threads} -d 3 -i {input.fixed} {input.moving} -n 30x0 -o {output.warp} &> {log}"
+        #"greedy -threads {threads} -d 3 -i {input.fixed} {input.moving} -n 30x0 -o {output.warp} &> {log}"
+        #"greedy -threads {threads} -d 3 -i {input.fixed} {input.moving} -n 100x50 -o {output.warp} &> {log}"
+        "greedy -threads {threads} -d 3 -i {input.fixed} {input.moving} -n 100x100 -s 1.0vox 0.3vox -o {output.warp} &> {log}"
 
 
 rule apply_halfsurf_warp_to_img:

--- a/hippunfold/workflow/rules/inner_outer_surf.smk
+++ b/hippunfold/workflow/rules/inner_outer_surf.smk
@@ -1,3 +1,4 @@
+import math
 
 
 rule compute_halfthick_mask:
@@ -49,7 +50,7 @@ rule compute_halfthick_mask:
         "c3d {input.coords} -threshold {params.threshold_tofrom} 1 0 {input.mask} -multiply -o {output}"
 
 
-rule register_midthickness:
+rule register_midthickness_syn:
     input:
         fixed=bids(
             root=root,
@@ -83,6 +84,110 @@ rule register_midthickness:
                 to="{inout}",
                 space="corobl",
                 hemi="{hemi}",
+                desc="syn",
+                **inputs.subj_wildcards,
+            )
+        ),
+        invwarp=temp(
+            bids(
+                root=root,
+                datatype="warps",
+                dir="IO",
+                label="{label}",
+                suffix="invxfm.nii.gz",
+                to="{inout}",
+                space="corobl",
+                hemi="{hemi}",
+                desc="syn",
+                **inputs.subj_wildcards,
+            )
+        ),
+    group:
+        "subj"
+    threads: 16
+    conda:
+        "../envs/ants.yaml"
+    params:
+        metric="MeanSquares",
+        metric_weight=1,
+        radius=0,
+        convergence="50x50x50",
+        convergence_thresh="1e-6",
+        convergence_window=10,
+        shrink_factors="4x2x1",
+        smoothing_sigmas="2x1x0vox",
+        syn_gradient_step=0.1,
+        syn_update_field_variance=config["inner_outer_reg_smoothing"],
+        syn_total_field_variance=0,
+    log:
+        bids_log(
+            "register_midthickness_ants",
+            **inputs.subj_wildcards,
+            hemi="{hemi}",
+            label="{label}",
+            to="{inout}",
+        ),
+    shadow:
+        "minimal"
+    shell:
+        r"""
+        tmp_prefix=ants_midthickness
+
+        antsRegistration \
+            --dimensionality 3 \
+            --float 1 \
+            --interpolation Linear \
+            --use-histogram-matching 0 \
+            --transform SyN[{params.syn_gradient_step},{params.syn_update_field_variance},{params.syn_total_field_variance}] \
+            --metric {params.metric}[{input.fixed},{input.moving},{params.metric_weight},{params.radius}] \
+            --convergence [{params.convergence},{params.convergence_thresh},{params.convergence_window}] \
+            --shrink-factors {params.shrink_factors} \
+            --smoothing-sigmas {params.smoothing_sigmas} \
+            --output [${{tmp_prefix}},${{tmp_prefix}}Warped.nii.gz] \
+            --verbose 1 
+
+        mv ${{tmp_prefix}}0Warp.nii.gz {output.warp}
+        mv ${{tmp_prefix}}0InverseWarp.nii.gz {output.invwarp}
+        """
+
+
+rule register_midthickness_greedy:
+    input:
+        fixed=bids(
+            root=root,
+            datatype="coords",
+            dir="IO",
+            label="{label}",
+            suffix="mask.nii.gz",
+            to="{inout}",
+            space="corobl",
+            hemi="{hemi}",
+            **inputs.subj_wildcards,
+        ),
+        moving=bids(
+            root=root,
+            datatype="coords",
+            suffix="mask.nii.gz",
+            space="corobl",
+            desc="GM",
+            hemi="{hemi}",
+            label="{label}",
+            **inputs.subj_wildcards,
+        ),
+    params:
+        update_field_sigma=math.sqrt(float(config["inner_outer_reg_smoothing"])),
+    output:
+        warp=temp(
+            bids(
+                root=root,
+                datatype="warps",
+                dir="IO",
+                label="{label}",
+                suffix="xfm.nii.gz",
+                to="{inout}",
+                space="corobl",
+                hemi="{hemi}",
+                desc="greedy",
                 **inputs.subj_wildcards,
             )
         ),
@@ -100,9 +205,7 @@ rule register_midthickness:
             to="{inout}",
         ),
     shell:
-        #"greedy -threads {threads} -d 3 -i {input.fixed} {input.moving} -n 30x0 -o {output.warp} &> {log}"
-        #"greedy -threads {threads} -d 3 -i {input.fixed} {input.moving} -n 100x50 -o {output.warp} &> {log}"
-        "greedy -threads {threads} -d 3 -i {input.fixed} {input.moving} -n 100x100 -s 1.0vox 0.3vox -o {output.warp} &> {log}"
+        "greedy -threads {threads} -d 3 -i {input.fixed} {input.moving} -n 50x50x50 -s {params.update_field_sigma}vox 0.707vox -o {output.warp} &> {log}"
 
 
 rule apply_halfsurf_warp_to_img:
@@ -137,6 +240,7 @@ rule apply_halfsurf_warp_to_img:
             to="{inout}",
             space="corobl",
             hemi="{hemi}",
+            desc=config["inner_outer_reg_method"],
             **inputs.subj_wildcards,
         ),
     output:
@@ -175,6 +279,7 @@ rule convert_inout_warp_from_itk_to_world:
             to="{inout}",
             space="corobl",
             hemi="{hemi}",
+            desc="{desc}",
             **inputs.subj_wildcards,
         ),
     output:
@@ -189,6 +294,7 @@ rule convert_inout_warp_from_itk_to_world:
                     to="{inout}",
                     space="corobl",
                     hemi="{hemi}",
+                    desc="{desc}",
                     **inputs.subj_wildcards,
                 )
             )
@@ -222,6 +328,7 @@ rule warp_midthickness_to_inout:
             to="{surfname}",
             space="corobl",
             hemi="{hemi}",
+            desc=config["inner_outer_reg_method"],
             **inputs.subj_wildcards,
         ),
     output:


### PR DESCRIPTION
Makes the greedy method configurable, and adds a configurable syn method. The previous default settings were leading to smooth thickness maps since the image registration was being done on downsampled images.