### PR TITLE
Add docker wrapper for hippunfold command to be exposed to apptainer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,11 @@ RUN set -e && \
     /app/entrypoint.sh hippunfold test_data/bids_dsegtissue test_out group_create_atlas --modality dsegtissue --derivatives test_data/bids_dsegtissue --new-atlas-name mytestatlas --new_atlas_subfields_from native --use-conda --conda-create-envs-only --cores all --conda-prefix /src/conda-envs --conda-frontend mamba && \
     rm -rf /root/.cache
 
+# Create hippunfold wrapper that uses pixi entrypoint
+RUN echo '#!/bin/bash' > /usr/local/bin/hippunfold && \
+    echo 'exec /app/entrypoint.sh hippunfold "$@"' >> /usr/local/bin/hippunfold && \
+    chmod +x /usr/local/bin/hippunfold
+
 # Create hippunfold-quick wrapper that uses pixi entrypoint
 RUN echo '#!/bin/bash' > /usr/local/bin/hippunfold-quick && \
     echo 'exec /app/entrypoint.sh /src/hippunfold/run_quick.py "$@"' >> /usr/local/bin/hippunfold-quick && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN set -e && \
 
 # Create hippunfold wrapper that uses pixi entrypoint
 RUN echo '#!/bin/bash' > /usr/local/bin/hippunfold && \
-    echo 'exec /app/entrypoint.sh hippunfold "$@"' >> /usr/local/bin/hippunfold && \
+    echo 'exec /app/entrypoint.sh /src/hippunfold/run.py "$@"' >> /usr/local/bin/hippunfold && \
     chmod +x /usr/local/bin/hippunfold
 
 # Create hippunfold-quick wrapper that uses pixi entrypoint


### PR DESCRIPTION
suggested  fix  for #564 

Claude helped me with this one. Apparently "apptainer exec" bypass the image entrypoints created by pixi entirely. Copying the wrapper for hippunfold-quick (which is working fine) should expose hippunfold to the apptainer exec too.

claude explanation in case it helps:
"Because ENTRYPOINT ["/app/entrypoint.sh"] is what activates the pixi environment (via pixi shell-hook), hippunfold only resolves on $PATH when the container is run through its entrypoint (docker run/apptainer run). Any invocation that bypasses the entrypoint — notably apptainer shell / apptainer exec, common for interactive debugging — leaves the pixi env unactivated, so hippunfold, python3, and pip are all missing from $PATH, while hippunfold-quick still works because it has its own static wrapper."