### PR TITLE
Fix checkpoint and trainer values for ADNI_T1w_v1

### DIFF
--- a/hippunfold/config/snakebids.yml
+++ b/hippunfold/config/snakebids.yml
@@ -471,8 +471,8 @@ nnunet_models:
     url: 'https://zenodo.org/record/15297857/files/trained_model.3d_fullres.Task301_ADNI_T1w_successful.nnUNetTrainer.tar'
     arch_version: nnunet_v1
     task: Task301_ADNI_T1w_successful
-    checkpoint:  model_best # --- confirm this
-    trainer: nnUNetTrainer  # --- confirm this
+    checkpoint:  nnUNetTrainer
+    trainer: Task301_ADNI_T1w_successful
 
   neonateT2w_v2:
     url: 'https://zenodo.org/records/17618449/files/Dataset302_dhcp_T2w_manuallycorrected.tar.gz'


### PR DESCRIPTION
This pull request updates the configuration for the `nnunet_models` section in `hippunfold/config/snakebids.yml` to correct the values for the `checkpoint` and `trainer` fields for the `adniT1w_v1` model.

Model configuration corrections:

* Changed the `checkpoint` value from `model_best` to `nnUNetTrainer` for the `adniT1w_v1` model.
* Changed the `trainer` value from `nnUNetTrainer` to `Task301_ADNI_T1w_successful` for the `adniT1w_v1` model.

Note: these seem to have been typos when originally training the model @Bradley-Karat, or maybe some files were manually renamed after training? 

This became a bug when we moved to explicit declaration of these values (which was done to support both v1 and v2 nnunet), rather than parsing them from the filename parts. 